### PR TITLE
Update quality-check.yaml

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -23,14 +23,14 @@ jobs:
       matrix:
         include:
           - python-version: 3.6
-            tensorflow: "~=2.4"
-            tensorflow_probability: "~=0.12"
+            tensorflow: "~=2.4.0"
+            tensorflow_probability: "~=0.12.0"
           - python-version: 3.7
-            tensorflow: ""
-            tensorflow_probability: ""
+            tensorflow: "~=2.4.0"  # temporarily restrict to TensorFlow 2.4.0
+            tensorflow_probability: "~=0.12.0"
           - python-version: 3.8
-            tensorflow: ""
-            tensorflow_probability: ""
+            tensorflow: "~=2.4.0"  # temporarily restrict to TensorFlow 2.4.0
+            tensorflow_probability: "~=0.12.0"
     name: Python-${{ matrix.python-version }} tensorflow${{ matrix.tensorflow }} tensorflow_probability${{ matrix.tensorflow_probability }}
     env:
       VERSION_TF: ${{ matrix.tensorflow }}


### PR DESCRIPTION
GPflux does not work at present with TensorFlow 2.5.0. @st-- has an open PR (#30) exploring how this could work. 

At present the develop build fails. This PR bounds the version of TensorFlow above by 2.5.0. 