### PR TITLE
Global inducing points implementation

### DIFF
--- a/gpflux/layers/__init__.py
+++ b/gpflux/layers/__init__.py
@@ -19,7 +19,7 @@ Layers
 from gpflux.layers import basis_functions
 from gpflux.layers.bayesian_dense_layer import BayesianDenseLayer
 from gpflux.layers.gp_layer import GPLayer
-from gpflux.layers.gi_gp_layer import GIGP
+from gpflux.layers.gi_gp_layer import GIGPLayer
 from gpflux.layers.latent_variable_layer import LatentVariableLayer, LayerWithObservations
-from gpflux.layers.likelihood_layer import LikelihoodLayer
+from gpflux.layers.likelihood_layer import LikelihoodLayer, SampleBasedGaussianLikelihoodLayer
 from gpflux.layers.trackable_layer import TrackableLayer

--- a/gpflux/layers/__init__.py
+++ b/gpflux/layers/__init__.py
@@ -19,6 +19,7 @@ Layers
 from gpflux.layers import basis_functions
 from gpflux.layers.bayesian_dense_layer import BayesianDenseLayer
 from gpflux.layers.gp_layer import GPLayer
+from gpflux.layers.gi_gp_layer import GIGP
 from gpflux.layers.latent_variable_layer import LatentVariableLayer, LayerWithObservations
 from gpflux.layers.likelihood_layer import LikelihoodLayer
 from gpflux.layers.trackable_layer import TrackableLayer

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -370,15 +370,3 @@ class GIGPLayer(tf.keras.layers.Layer):
         logpq = logP - logQ
 
         return -tf.reduce_mean(logpq)
-
-    def sample(self, inputs: TensorType) -> tf.Tensor:
-        """
-        Sample consistent functions from the layer.
-
-        TODO: Note that this not follow the behavior of the :class:`Sample` in the rest of GPflux.
-
-        :param inputs: [..., Lin]
-        :return: consistent samples, shape [..., Lout]
-        """
-
-        return self.call(inputs, kwargs={"training": None, "full_cov": True})

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -266,7 +266,7 @@ class GIGPLayer(tf.keras.layers.Layer):
         name = f"{self.name}_prior_kl" if self.name else "prior_kl"
         self.add_metric(loss_per_datapoint, name=name, aggregation="mean")
 
-        #### f|u
+        #### f|u - possibility of using a conditional here?
         Kfu_invKuu = tf.linalg.adjoint(tf.linalg.cholesky_solve(chol_Kuu, Kuf))
         Ef = tf.linalg.adjoint(tf.squeeze((Kfu_invKuu @ u), -1))
         Vf = Kff - tf.squeeze(tf.reduce_sum((Kfu_invKuu*Kfu), -1), 1)

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -39,9 +39,6 @@ class BatchingSquaredExponential(SquaredExponential):
     shape [..., N, D], and X2 with shape [..., M, D], we return [..., N, M] instead of the current
     behavior, which returns [..., N, ..., M]"""
 
-    def K_r2(self, r2):
-        return self.variance * tf.exp(-0.5 * r2)
-
     def scaled_squared_euclid_dist(self, X, X2=None):
         X = self.scale(X)
         X2 = self.scale(X2)

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -48,7 +48,7 @@ class BatchingSquaredExponential(SquaredExponential):
 
         Xs = tf.reduce_sum((X**2), -1)[..., :, None]
         X2s = tf.reduce_sum((X2**2), -1)[..., None, :]
-        return Xs + X2s - 2*X@tf.linalg.adjoint(X2)
+        return Xs + X2s - 2 * tf.linalg.matmul(X, X2, transpose_b=True)
 
 
 class GIGPLayer(tf.keras.layers.Layer):

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -1,0 +1,315 @@
+#
+# Copyright (c) 2021 The GPflux Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+This module provides :class:`GIGPLayer`, which implements a 'global inducing' point posterior for
+a GP layer. Currently restricted to single-output kernels, inducing points, etc... See Ober and
+Aitchison (2021) for details.
+"""
+
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+import math
+
+from gpflow import Parameter, default_float
+from gpflow.base import TensorType
+from gpflow.kernels import SquaredExponential
+from gpflow.mean_functions import Identity, MeanFunction
+from gpflow.utilities.bijectors import triangular, positive
+
+from gpflux.sampling.sample import Sample
+
+
+class BatchingSquaredExponential(SquaredExponential):
+    """Implementation of squared exponential kernel that batches in the following way: given X with
+    shape [..., N, D], and X2 with shape [..., M, D], we return [..., N, M] instead of the current
+    behavior, which returns [..., N, ..., M]"""
+
+    def K_r2(self, r2):
+        return self.variance * tf.exp(-0.5 * r2)
+
+    def scaled_squared_euclid_dist(self, X, X2=None):
+        X = self.scale(X)
+        X2 = self.scale(X2)
+
+        if X2 is None:
+            X2 = X
+
+        Xs = tf.reduce_sum((X**2), -1)[..., :, None]
+        X2s = tf.reduce_sum((X2**2), -1)[..., None, :]
+        return Xs + X2s - 2*X@tf.linalg.adjoint(X2s)
+
+
+class GIGPLayer(tf.keras.layers.Layer):
+    """
+    A sparse variational multioutput GP layer. This layer holds the kernel,
+    inducing variables and variational distribution, and mean function.
+    """
+
+    num_data: int
+    """
+    The number of points in the training dataset. This information is used to
+    obtain the correct scaling between the data-fit and the KL term in the
+    evidence lower bound (ELBO).
+    """
+
+    v: Parameter
+    r"""
+    The pseudo-targets. 
+    """
+
+    L_loc: Parameter
+    r"""
+    The lower-triangular Cholesky factor of the precision of ``q(u|v)``.
+    """
+
+    L_scale: Parameter
+    r"""
+    Scale parameter for L
+    """
+
+    def __init__(
+        self,
+        num_latent_gps: int,
+        num_data: int,
+        num_inducing: int,
+        input_dim: int,
+        inducing_targets: Optional[tf.Tensor] = None,
+        prec_init: Optional[float] = 1.,
+        mean_function: Optional[MeanFunction] = None,
+        *,
+        name: Optional[str] = None,
+        verbose: bool = True,
+    ):
+        """
+        :param kernel: The multioutput kernel for this layer.
+        :param inducing_variable: The inducing features for this layer.
+        :param num_data: The number of points in the training dataset (see :attr:`num_data`).
+        :param mean_function: The mean function that will be applied to the
+            inputs. Default: :class:`~gpflow.mean_functions.Identity`.
+
+            .. note:: The Identity mean function requires the input and output
+                dimensionality of this layer to be the same. If you want to
+                change the dimensionality in a layer, you may want to provide a
+                :class:`~gpflow.mean_functions.Linear` mean function instead.
+
+        :param num_samples: The number of samples to draw when converting the
+            :class:`~tfp.layers.DistributionLambda` into a `tf.Tensor`, see
+            :meth:`_convert_to_tensor_fn`. Will be stored in the
+            :attr:`num_samples` attribute.  If `None` (the default), draw a
+            single sample without prefixing the sample shape (see
+            :class:`tfp.distributions.Distribution`'s `sample()
+            <https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Distribution#sample>`_
+            method).
+        :param full_cov: Sets default behaviour of calling this layer
+            (:attr:`full_cov` attribute):
+            If `False` (the default), only predict marginals (diagonal
+            of covariance) with respect to inputs.
+            If `True`, predict full covariance over inputs.
+        :param full_output_cov: Sets default behaviour of calling this layer
+            (:attr:`full_output_cov` attribute):
+            If `False` (the default), only predict marginals (diagonal
+            of covariance) with respect to outputs.
+            If `True`, predict full covariance over outputs.
+        :param num_latent_gps: The number of (latent) GPs in the layer
+            (which can be different from the number of outputs, e.g. with a
+            :class:`~gpflow.kernels.LinearCoregionalization` kernel).
+            This is used to determine the size of the
+            variational parameters :attr:`q_mu` and :attr:`q_sqrt`.
+            If possible, it is inferred from the *kernel* and *inducing_variable*.
+        :param whiten: If `True` (the default), uses the whitened parameterisation
+            of the inducing variables; see :attr:`whiten`.
+        :param name: The name of this layer.
+        :param verbose: The verbosity mode. Set this parameter to `True`
+            to show debug information.
+        """
+
+        super().__init__(
+            make_distribution_fn=self._make_distribution_fn,
+            convert_to_tensor_fn=self._convert_to_tensor_fn,
+            dtype=default_float(),
+            name=name,
+        )
+
+        self.kernel = BatchingSquaredExponential(lengthscales=[1.]*input_dim)
+
+        self.num_data = num_data
+
+        if mean_function is None:
+            mean_function = Identity()
+            if verbose:
+                warnings.warn(
+                    "Beware, no mean function was specified in the construction of the `GPLayer` "
+                    "so the default `gpflow.mean_functions.Identity` is being used. "
+                    "This mean function will only work if the input dimensionality "
+                    "matches the number of latent Gaussian processes in the layer."
+                )
+        self.mean_function = mean_function
+
+        self.verbose = verbose
+
+        self.num_latent_gps = num_latent_gps
+
+        self.num_inducing = num_inducing
+
+        if inducing_targets is None:
+            inducing_targets = np.zeros((self.num_latent_gps, num_inducing, 1))
+
+        self.v = Parameter(
+            inducing_targets,
+            dtype=default_float(),
+            name=f"{self.name}_v" if self.name else "v",
+        )
+
+        self.L_loc = Parameter(
+            np.stack([np.eye(num_inducing) for _ in range(self.num_latent_gps)]),
+            transform=triangular(),
+            dtype=default_float(),
+            name=f"{self.name}_L_loc" if self.name else "L_loc",
+        )  # [num_latent_gps, num_inducing, num_inducing]
+
+        self.L_scale = Parameter(
+            np.sqrt(prec_init)*np.ones((self.num_latent_gps, 1, 1)),
+            transform=positive(),
+            dtype=default_float(),
+            name=f"{self.name}_L_scale" if self.name else "L_scale"
+        )
+
+    @property
+    def L(self):
+        norm = tf.reshape(tf.reduce_mean(tf.linalg.diag_part(self.L_loc), axis=-1), [-1, 1, 1])
+        return self.L_loc * self.L_scale/norm
+
+    def mvnormal_log_prob(self, sigma_L, X):
+        in_features = tf.shape(X)[-2]
+        out_features = tf.shape(X)[-1]
+        trace_quad = tf.reduce_sum(tf.linalg.triangular_solve(sigma_L, X)**2, [-1, -2])
+        logdet_term = 2.0*tf.reduce_sum(tf.math.log(tf.linalg.diag_part(sigma_L)), -1)
+        return -0.5*trace_quad - 0.5*out_features*(logdet_term + in_features*math.log(2*math.pi))
+
+    def call(
+        self,
+        inputs: TensorType,
+        *args: List[Any],
+        **kwargs: Dict[str, Any]
+    ) -> tf.Tensor:
+        """
+        Sample-based propagation of both inducing points and function values.
+        """
+        assert len(tf.shape(inputs)) == 3
+
+        mean_function = self.mean_function(inputs)
+
+        Kuu = self.kernel(inputs[..., :self.num_inducing])
+        Kuf = self.kernel(inputs[..., :self.num_inducing, self.num_inducing:])
+        Kfu = tf.linalg.adjoint(Kuf)
+        Kff = self.kernel.K_diag(inputs[..., self.num_inducing:])
+
+        Kuu, Kuf, Kfu = tf.expand_dims(Kuu, 1), tf.expand_dims(Kuf, 1), tf.expand_dims(Kfu, 1)
+
+        (S, _, _, _) = tf.shape(Kuu)
+        S = S.numpy()
+
+        Iuu = tf.eye(self.num_inducing, dtype=default_float())
+
+        L = self.L
+        LT = tf.linalg.adjoint(L)
+
+        KuuL = Kuu @ L
+
+        lKlpI = LT @ KuuL + Iuu
+        chol_lKlpI = tf.linalg.cholesky(lKlpI)
+        Sigma = Kuu - KuuL @ tf.linalg.cholesky_solve(chol_lKlpI, tf.linalg.adjoint(KuuL))
+
+        eps_1 = tf.random.normal(
+            [S, self.num_latent_gps, self.num_inducing, 1],
+            dtype=default_float()
+        )
+        eps_2 = tf.random.normal(
+            [S, self.num_latent_gps, self.num_inducing, 1],
+            dtype=default_float()
+        )
+
+        chol_Kuu = tf.linalg.cholesky(Kuu)
+        chol_Kuu_T = tf.linalg.adjoint(chol_Kuu)
+
+        inv_Kuu_noise = tf.linalg.triangular_solve(chol_Kuu_T, eps_1, lower=False)
+        L_noise = L @ eps_2
+        prec_noise = inv_Kuu_noise + L_noise
+        u = Sigma @ ((L @ LT) @ self.v + prec_noise)
+
+        if kwargs.get("training"):
+            loss_per_datapoint = self.prior_kl(LT, chol_lKlpI, u) / self.num_data
+        else:
+            # TF quirk: add_loss must always add a tensor to compile
+            loss_per_datapoint = tf.constant(0.0, dtype=default_float())
+        self.add_loss(loss_per_datapoint)
+
+        # Metric names should be unique; otherwise they get overwritten if you
+        # have multiple with the same name
+        name = f"{self.name}_prior_kl" if self.name else "prior_kl"
+        self.add_metric(loss_per_datapoint, name=name, aggregation="mean")
+
+        #### f|u
+        Kfu_invKuu = tf.linalg.adjoint(tf.linalg.cholesky_solve(chol_Kuu, Kuf))
+        Ef = tf.linalg.adjoint(tf.squeeze((Kfu_invKuu @ u), -1))
+        Vf = Kff - tf.squeeze(tf.reduce_sum((Kfu_invKuu*Kfu), -1), 1)
+
+        eps_f = tf.random.normal(
+            tf.shape(Ef),
+            dtype=default_float()
+        )
+
+        f_samples = Ef + tf.math.sqrt(Vf)[..., None]*eps_f
+
+        all_samples = tf.concat(
+            [
+                tf.linalg.adjoint(tf.squeeze(u, -1)),
+                f_samples,
+            ],
+            axis=-2
+        )
+
+        return all_samples + mean_function
+
+    def prior_kl(
+        self,
+        LT: tf.Tensor,
+        chol_lKlpI: tf.Tensor,
+        u: tf.Tensor,
+    ) -> tf.Tensor:
+        r"""
+        Returns the KL divergence ``KL[q(u)∥p(u)]`` from the prior ``p(u)`` to
+        the variational distribution ``q(u)``.  If this layer uses the
+        :attr:`whiten`\ ed representation, returns ``KL[q(v)∥p(v)]``.
+        """
+        lv = LT @ self.v
+
+        logP = tf.reduce_sum(self.mvnormal_log_prob(chol_lKlpI, lv), -1)
+        logQ = tf.reduce_sum(tfp.distributions.Normal(LT@u, 1.).log_prob(lv), [-1, -2, -3])
+
+        logpq = logP - logQ
+
+        return -tf.reduce_mean(logpq)
+
+    def sample(self) -> Sample:
+        """
+        .. todo:: TODO: Document this.
+        """
+        raise NotImplementedError("TODO")

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -229,6 +229,42 @@ class GIGPLayer(tf.keras.layers.Layer):
 
         S = tf.shape(Kuu)[0]
 
+        u, chol_lKlpI, chol_Kuu = self.sample_u(S, Kuu)
+
+        if kwargs.get("training"):
+            loss_per_datapoint = self.prior_kl(tf.linalg.adjoint(self.L), chol_lKlpI, u) / self.num_data
+        else:
+            # TF quirk: add_loss must always add a tensor to compile
+            loss_per_datapoint = tf.constant(0.0, dtype=default_float())
+        self.add_loss(loss_per_datapoint)
+
+        # Metric names should be unique; otherwise they get overwritten if you
+        # have multiple with the same name
+        name = f"{self.name}_prior_kl" if self.name else "prior_kl"
+        self.add_metric(loss_per_datapoint, name=name, aggregation="mean")
+
+        if kwargs.get("full_cov"):
+            f_samples = self.sample_conditional(u, Kff, Kuf, chol_Kuu, inputs=inputs, full_cov=True)
+        else:
+            f_samples = self.sample_conditional(u, Kff, Kuf, chol_Kuu)
+
+        all_samples = tf.concat(
+            [
+                tf.linalg.adjoint(tf.squeeze(u, -1)),
+                f_samples,
+            ],
+            axis=-2
+        )
+
+        return all_samples + mean_function
+
+    def sample_u(
+        self,
+        S: int,
+        Kuu: TensorType
+    ) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+        # Samples inducing locations u
+
         Iuu = tf.eye(self.num_inducing, dtype=default_float())
 
         L = self.L
@@ -258,32 +294,7 @@ class GIGPLayer(tf.keras.layers.Layer):
         prec_noise = inv_Kuu_noise + L_noise
         u = Sigma @ ((L @ LT) @ self.v + prec_noise)
 
-        if kwargs.get("training"):
-            loss_per_datapoint = self.prior_kl(LT, chol_lKlpI, u) / self.num_data
-        else:
-            # TF quirk: add_loss must always add a tensor to compile
-            loss_per_datapoint = tf.constant(0.0, dtype=default_float())
-        self.add_loss(loss_per_datapoint)
-
-        # Metric names should be unique; otherwise they get overwritten if you
-        # have multiple with the same name
-        name = f"{self.name}_prior_kl" if self.name else "prior_kl"
-        self.add_metric(loss_per_datapoint, name=name, aggregation="mean")
-
-        if kwargs.get("full_cov"):
-            f_samples = self.sample_conditional(u, Kff, Kuf, chol_Kuu, inputs=inputs, full_cov=True)
-        else:
-            f_samples = self.sample_conditional(u, Kff, Kuf, chol_Kuu)
-
-        all_samples = tf.concat(
-            [
-                tf.linalg.adjoint(tf.squeeze(u, -1)),
-                f_samples,
-            ],
-            axis=-2
-        )
-
-        return all_samples + mean_function
+        return u, chol_lKlpI, chol_Kuu
 
     def predict(
         self,

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -94,6 +94,7 @@ class GIGPLayer(tf.keras.layers.Layer):
         inducing_targets: Optional[tf.Tensor] = None,
         prec_init: Optional[float] = 1.,
         mean_function: Optional[MeanFunction] = None,
+        kernel_variance_init: Optional[float] = 1.,
         *,
         name: Optional[str] = None,
         verbose: bool = True,
@@ -146,7 +147,8 @@ class GIGPLayer(tf.keras.layers.Layer):
             name=name,
         )
 
-        self.kernel = BatchingSquaredExponential(lengthscales=[1.]*input_dim)
+        self.kernel = BatchingSquaredExponential(
+            lengthscales=[1.]*input_dim, variance=kernel_variance_init)
 
         self.input_dim = input_dim
 
@@ -186,7 +188,7 @@ class GIGPLayer(tf.keras.layers.Layer):
         )  # [num_latent_gps, num_inducing, num_inducing]
 
         self.L_scale = Parameter(
-            np.sqrt(prec_init)*np.ones((self.num_latent_gps, 1, 1)),
+            tf.sqrt(self.kernel.variance)*np.sqrt(prec_init)*np.ones((self.num_latent_gps, 1, 1)),
             transform=positive(),
             dtype=default_float(),
             name=f"{self.name}_L_scale" if self.name else "L_scale"

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -205,8 +205,8 @@ class GIGPLayer(tf.keras.layers.Layer):
         :param X: evaluation point for log_prob, shape [..., M, D, 1]
         :return: the log probability, shape [..., M]
         """
-        in_features = self.input_dim
-        out_features = self.num_latent_gps
+        in_features = tf.cast(tf.shape(X)[-2], dtype=default_float())
+        out_features = tf.cast(tf.shape(X)[-1], dtype=default_float())
         trace_quad = tf.reduce_sum(tf.linalg.triangular_solve(sigma_L, X)**2, [-1, -2])
         logdet_term = 2.0*tf.reduce_sum(tf.math.log(tf.linalg.diag_part(sigma_L)), -1)
         return -0.5*trace_quad - 0.5*out_features*(logdet_term + in_features*math.log(2*math.pi))

--- a/gpflux/layers/gi_gp_layer.py
+++ b/gpflux/layers/gi_gp_layer.py
@@ -92,11 +92,11 @@ class GIGPLayer(tf.keras.layers.Layer):
         num_latent_gps: int,
         num_data: int,
         num_inducing: int,
+        *,
         inducing_targets: Optional[tf.Tensor] = None,
         prec_init: Optional[float] = 1.,
         mean_function: Optional[MeanFunction] = None,
         kernel_variance_init: Optional[float] = 1.,
-        *,
         name: Optional[str] = None,
         verbose: bool = True,
     ):

--- a/gpflux/layers/likelihood_layer.py
+++ b/gpflux/layers/likelihood_layer.py
@@ -49,7 +49,7 @@ class SampleBasedGaussianLikelihoodLayer(TrackableLayer):
         targets: Optional[TensorType] = None,
         training: bool = None,
     ) -> tfp.distributions.Normal:
-        likelihood_dist = tfp.distributions.Normal(inputs, self.variance, dtype=default_float())
+        likelihood_dist = tfp.distributions.Normal(inputs, tf.sqrt(self.variance))
 
         if training:
             assert targets is not None

--- a/gpflux/models/__init__.py
+++ b/gpflux/models/__init__.py
@@ -17,3 +17,4 @@
 Base model classes implemented in GPflux
 """
 from gpflux.models.deep_gp import DeepGP
+from gpflux.models.gi_deep_gp import GIDeepGP

--- a/gpflux/models/gi_deep_gp.py
+++ b/gpflux/models/gi_deep_gp.py
@@ -146,8 +146,8 @@ class GIDeepGP(Module):
         self.default_model_class = default_model_class
         self.num_data = self._validate_num_data(f_layers, num_data)
 
-        if (inducing_init is not None) != (inducing_shape is not None):
-            raise ValueError(f"One of `inducing_init` or `inducing_shape` must be exclusively"
+        if (inducing_init is not None) == (inducing_shape is not None):
+            raise ValueError(f"One of `inducing_init` or `inducing_shape` must be exclusively "
                              f"provided.")
 
         if inducing_init is None:
@@ -158,7 +158,7 @@ class GIDeepGP(Module):
         if num_inducing != tf.shape(self.inducing_data)[0]:
             raise ValueError(f"The number of inducing inputs {self.inducing_data.shape[0]} must "
                              f"equal num_inducing {num_inducing}.")
-        if input_dim is not None and input_dim != tf.shape(self.inducing_data)[-1]:
+        if input_dim is not None and tf.shape(self.inducing_data)[-1] != input_dim:
             raise ValueError(f"The dimension of the inducing inputs {self.inducing_data.shape[-1]}"
                              f"must equal input_dim {input_dim}")
 

--- a/gpflux/models/gi_deep_gp.py
+++ b/gpflux/models/gi_deep_gp.py
@@ -95,7 +95,7 @@ class GIDeepGP(Module):
         assert (inducing_init is not None) != (inducing_shape is not None)
 
         if inducing_init is None:
-            self.inducing_data = Parameter(inducing_shape, dtype=default_float())
+            self.inducing_data = Parameter(tf.random.normal(inducing_shape), dtype=default_float())
         else:
             self.inducing_data = Parameter(inducing_init, dtype=default_float())
 

--- a/gpflux/models/gi_deep_gp.py
+++ b/gpflux/models/gi_deep_gp.py
@@ -1,0 +1,301 @@
+#
+# Copyright (c) 2021 The GPflux Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" This module provides an implementation of global inducing points for deep GPs. """
+
+import itertools
+from typing import List, Optional, Tuple, Type, Union
+
+import tensorflow as tf
+
+import gpflow
+from gpflow import Parameter, default_float
+from gpflow.base import Module, TensorType
+
+import gpflux
+from gpflux.layers import LayerWithObservations, LikelihoodLayer, SampleBasedGaussianLikelihoodLayer
+from gpflux.sampling.sample import Sample
+
+
+class GIDeepGP(Module):
+
+    f_layers: List[tf.keras.layers.Layer]
+    """ A list of all layers in this DeepGP (just :attr:`likelihood_layer` is separate). """
+
+    likelihood_layer: gpflux.layers.LikelihoodLayer
+    """ The likelihood layer. """
+
+    """
+    The default for the *model_class* argument of :meth:`as_training_model` and
+    :meth:`as_prediction_model`. This must have the same semantics as `tf.keras.Model`,
+    that is, it must accept a list of inputs and an output. This could be
+    `tf.keras.Model` itself or `gpflux.optimization.NatGradModel` (but not, for
+    example, `tf.keras.Sequential`).
+    """
+
+    num_data: int
+    """
+    The number of points in the training dataset. This information is used to
+    obtain correct scaling between the data-fit and the KL term in the evidence
+    lower bound (:meth:`elbo`).
+    """
+
+    def __init__(
+        self,
+        f_layers: List[tf.keras.layers.Layer],
+        num_inducing: int,
+        *,
+        likelihood_var: Optional[float] = 1.0,
+        inducing_init: Optional[tf.Tensor] = None,
+        inducing_shape: Optional[List[int]] = None,
+        input_dim: Optional[int] = None,
+        target_dim: Optional[int] = None,
+        default_model_class: Type[tf.keras.Model] = tf.keras.Model,
+        num_data: Optional[int] = None,
+        num_train_samples: Optional[int] = 10,
+        num_test_samples: Optional[int] = 100,
+    ):
+        """
+        :param f_layers: The layers ``[f₁, f₂, …, fₙ]`` describing the latent
+            function ``f(x) = fₙ(⋯ (f₂(f₁(x))))``.
+        :param likelihood: The layer for the likelihood ``p(y|f)``. If this is a
+            GPflow likelihood, it will be wrapped in a :class:`~gpflux.layers.LikelihoodLayer`.
+            Alternatively, you can provide a :class:`~gpflux.layers.LikelihoodLayer` explicitly.
+        :param input_dim: The input dimensionality.
+        :param target_dim: The target dimensionality.
+        :param default_model_class: The default for the *model_class* argument of
+            :meth:`as_training_model` and :meth:`as_prediction_model`;
+            see the :attr:`default_model_class` attribute.
+        :param num_data: The number of points in the training dataset; see the
+            :attr:`num_data` attribute.
+            If you do not specify a value for this parameter explicitly, it is automatically
+            detected from the :attr:`~gpflux.layers.GPLayer.num_data` attribute in the GP layers.
+        """
+        self.inputs = tf.keras.Input((input_dim,), name="inputs")
+        self.targets = tf.keras.Input((target_dim,), name="targets")
+        self.f_layers = f_layers
+        self.likelihood_layer = SampleBasedGaussianLikelihoodLayer(variance=likelihood_var)
+        self.num_inducing = num_inducing
+        self.default_model_class = default_model_class
+        self.num_data = self._validate_num_data(f_layers, num_data)
+
+        assert (inducing_init is not None) != (inducing_shape is not None)
+
+        if inducing_init is None:
+            self.inducing_data = Parameter(inducing_shape, dtype=default_float())
+        else:
+            self.inducing_data = Parameter(inducing_init, dtype=default_float())
+
+        assert num_inducing == tf.shape(self.inducing_data)[0]
+        self.rank = 1 + len(tf.shape(self.inducing_data))
+
+        self.num_train_samples = num_train_samples
+        self.num_test_samples = num_test_samples
+
+    @staticmethod
+    def _validate_num_data(
+        f_layers: List[tf.keras.layers.Layer], num_data: Optional[int] = None
+    ) -> int:
+        """
+        Check that the :attr:`~gpflux.layers.gp_layer.GPLayer.num_data`
+        attributes of all layers in *f_layers* are consistent with each other
+        and with the (optional) *num_data* argument.
+
+        :returns: The validated number of datapoints.
+        """
+        for i, layer in enumerate(f_layers):
+            layer_num_data = getattr(layer, "num_data", None)
+            if num_data is None:
+                num_data = layer_num_data
+            else:
+                if layer_num_data is not None and num_data != layer_num_data:
+                    raise ValueError(
+                        f"f_layers[{i}].num_data is inconsistent with num_data={num_data}"
+                    )
+        if num_data is None:
+            raise ValueError("Could not determine num_data; please provide explicitly")
+        return num_data
+
+    def _inducing_add(self, inputs: TensorType):
+        assert self.rank == len(tf.shape(inputs))
+
+        inducing_data = tf.tile(
+            tf.expand_dims(self.inducing_data, 0),
+            [tf.shape(inputs)[0], *tf.shape(self.inducing_data)]
+        )
+        x = tf.concat([inducing_data, inputs], 1)
+
+        return x
+
+    def _inducing_remove(self, inputs: TensorType):
+        return inputs[:, self.num_inducing:]
+
+    def _evaluate_deep_gp(
+        self,
+        inputs: TensorType,
+        targets: Optional[TensorType],
+        training: Optional[bool] = None,
+    ) -> tf.Tensor:
+        """
+        Evaluate ``f(x) = fₙ(⋯ (f₂(f₁(x))))`` on the *inputs* argument.
+
+        Layers that inherit from :class:`~gpflux.layers.LayerWithObservations`
+        are passed the additional keyword argument ``observations=[inputs,
+        targets]`` if *targets* contains a value, or ``observations=None`` when
+        *targets* is `None`.
+        """
+        features = inputs
+
+        # NOTE: we cannot rely on the `training` flag here, as the correct
+        # symbolic graph needs to be constructed at "build" time (before either
+        # fit() or predict() get called).
+        if targets is not None:
+            observations = [inputs, targets]
+            num_samples = self.num_train_samples
+        else:
+            # TODO would it be better to simply pass [inputs, None] in this case?
+            observations = None
+            num_samples = self.num_test_samples
+
+        features = tf.tile(tf.expand_dims(features, 0), [num_samples, *[1]*len(tf.shape(features))])
+        features = self._inducing_add(features)
+
+        for layer in self.f_layers:
+            if isinstance(layer, LayerWithObservations):
+                raise NotImplementedError("Latent variable layers not yet supported")
+            else:
+                features = layer(features, training=training)
+        return self._inducing_remove(features)
+
+    def _evaluate_likelihood(
+        self,
+        f_outputs: TensorType,
+        targets: Optional[TensorType],
+        training: Optional[bool] = None,
+    ) -> tf.Tensor:
+        """
+        Call the `likelihood_layer` on *f_outputs*, which adds the
+        corresponding layer loss when training.
+        """
+        return self.likelihood_layer(f_outputs, targets=targets, training=training)
+
+    def call(
+        self,
+        inputs: TensorType,
+        targets: Optional[TensorType] = None,
+        training: Optional[bool] = None,
+    ) -> tf.Tensor:
+        f_outputs = self._evaluate_deep_gp(inputs, targets=targets, training=training)
+        y_outputs = self._evaluate_likelihood(f_outputs, targets=targets, training=training)
+        return y_outputs
+
+    # def predict_f(self, inputs: TensorType) -> Tuple[tf.Tensor, tf.Tensor]:
+    #     """
+    #     :returns: The mean and variance (not the scale!) of ``f``, for compatibility with GPflow
+    #        models.
+    #
+    #     .. note:: This method does **not** support ``full_cov`` or ``full_output_cov``.
+    #     """
+    #     f_distribution = self._evaluate_deep_gp(inputs, targets=None)
+    #     return f_distribution.loc, f_distribution.scale.diag ** 2
+
+    def elbo(self, data: Tuple[TensorType, TensorType]) -> tf.Tensor:
+        """
+        :returns: The ELBO (not the per-datapoint loss!), for compatibility with GPflow models.
+        """
+        X, Y = data
+        _ = self.call(X, Y, training=True)
+        all_losses = [
+            loss
+            for layer in itertools.chain(self.f_layers, [self.likelihood_layer])
+            for loss in layer.losses
+        ]
+        return -tf.reduce_sum(all_losses) * self.num_data
+
+    def _get_model_class(self, model_class: Optional[Type[tf.keras.Model]]) -> Type[tf.keras.Model]:
+        if model_class is not None:
+            return model_class
+        else:
+            return self.default_model_class
+
+    def as_training_model(
+        self, model_class: Optional[Type[tf.keras.Model]] = None
+    ) -> tf.keras.Model:
+        r"""
+        Construct a `tf.keras.Model` instance that requires you to provide both ``inputs``
+        and ``targets`` to its call. This information is required for
+        training the model, because the ``targets`` need to be passed to the `likelihood_layer` (and
+        to :class:`~gpflux.layers.LayerWithObservations` instances such as
+        :class:`~gpflux.layers.LatentVariableLayer`\ s, if present).
+
+        When compiling the returned model, do **not** provide any additional
+        losses (this is handled by the :attr:`likelihood_layer`).
+
+        Train with
+
+        .. code-block:: python
+
+            model.compile(optimizer)  # do NOT pass a loss here
+            model.fit({"inputs": X, "targets": Y}, ...)
+
+        See `Keras's Endpoint layer pattern
+        <https://keras.io/examples/keras_recipes/endpoint_layer_pattern/>`_
+        for more details.
+
+        .. note:: Use `as_prediction_model` if you want only to predict, and do not want to pass in
+           a dummy array for the targets.
+
+        :param model_class: The model class to use; overrides `default_model_class`.
+        """
+        model_class = self._get_model_class(model_class)
+        outputs = self.call(self.inputs, self.targets)
+        return model_class([self.inputs, self.targets], outputs)
+
+    def as_prediction_model(
+        self, model_class: Optional[Type[tf.keras.Model]] = None
+    ) -> tf.keras.Model:
+        """
+        Construct a `tf.keras.Model` instance that requires only ``inputs``,
+        which means you do not have to provide dummy target values when
+        predicting at test points.
+
+        Predict with
+
+        .. code-block:: python
+
+            model.predict(Xtest, ...)
+
+        .. note:: The returned model will not support training; for that, use `as_training_model`.
+
+        :param model_class: The model class to use; overrides `default_model_class`.
+        """
+        model_class = self._get_model_class(model_class)
+        outputs = self.call(self.inputs)
+        return model_class(self.inputs, outputs)
+
+
+def sample_dgp(model: GIDeepGP) -> Sample:  # TODO: should this be part of a [Vanilla]DeepGP class?
+    function_draws = [layer.sample() for layer in model.f_layers]
+    # TODO: error check that all layers implement .sample()?
+
+    class ChainedSample(Sample):
+        """ This class chains samples from consecutive layers. """
+
+        def __call__(self, X: TensorType) -> tf.Tensor:
+            for f in function_draws:
+                X = f(X)
+            return X
+
+    return ChainedSample()

--- a/gpflux/models/gi_deep_gp.py
+++ b/gpflux/models/gi_deep_gp.py
@@ -285,7 +285,7 @@ class GIDeepGP(Module):
         outputs = self.call(self.inputs)
         return model_class(self.inputs, outputs)
 
-    def sample(self, inputs: TensorType, num_samples: int) -> tf.Tensor:
+    def sample(self, inputs: TensorType, num_samples: int, consistent: bool = False) -> tf.Tensor:
         features = tf.tile(tf.expand_dims(inputs, 0),
                            [num_samples, *[1]*(self.rank-1)])
         features = self._inducing_add(features)
@@ -294,7 +294,7 @@ class GIDeepGP(Module):
             if isinstance(layer, LayerWithObservations):
                 raise NotImplementedError("Latent variable layers not yet supported")
             else:
-                features = layer(features, training=None, full_cov=True)
+                features = layer(features, training=None, full_cov=consistent)
 
         return self._inducing_remove(features)
 


### PR DESCRIPTION
Quick implementation of "global inducing" approximate posteriors for basic DGPs (see Ober and Aitchison (2021): https://arxiv.org/abs/2005.08140). TODOs:

- Fix/better documentation
- Write tests
- Investigate broken Keras
- Support for multioutput kernels + resolve GPflow kernel issue
- Make sampling compatible with (efficient) sampling in gpflux.sampling
- See if more GPflow functionalities can be used (e.g. conditionals)