### PR TITLE
Make RFF weights explicitly not trainable

### DIFF
--- a/gpflux/layers/basis_functions/random_fourier_features.py
+++ b/gpflux/layers/basis_functions/random_fourier_features.py
@@ -89,7 +89,7 @@ class RandomFourierFeatures(tf.keras.layers.Layer):
             trainable=False,
             shape=shape_bias,
             dtype=self.dtype,
-            initializer=self.bias_init
+            initializer=self.bias_init,
         )
 
         shape_weights = [self.output_dim, input_dim]

--- a/gpflux/layers/basis_functions/random_fourier_features.py
+++ b/gpflux/layers/basis_functions/random_fourier_features.py
@@ -85,12 +85,17 @@ class RandomFourierFeatures(tf.keras.layers.Layer):
 
         shape_bias = [1, self.output_dim]
         self.b = self.add_weight(
-            name="bias", shape=shape_bias, dtype=self.dtype, initializer=self.bias_init
+            name="bias",
+            trainable=False,
+            shape=shape_bias,
+            dtype=self.dtype,
+            initializer=self.bias_init
         )
 
         shape_weights = [self.output_dim, input_dim]
         self.W = self.add_weight(
             name="weights",
+            trainable=False,
             shape=shape_weights,
             dtype=self.dtype,
             initializer=self.weights_init,


### PR DESCRIPTION
Parameters created with `add_weight` in Keras Layers are trainable by default. This could potentially introduce bugs and unexpected behaviours down the line.