### PR TITLE
Place upper bound on TensorFlow (Probability) dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ requirements = [
     "gpflow>=2.1",
     "numpy",
     "scipy",
-    "tensorflow-probability>=0.12.0",
-    "tensorflow>=2.5.0",
+    "tensorflow>=2.5.0,<2.6.0",
+    "tensorflow-probability>=0.12.0,<0.14.0",
 ]
 
 with open("README.md", "r") as file:


### PR DESCRIPTION
TensorFlow (TF) 2.6.0 introduces some breaking changes. Until these are addressed, we must ensure the versions installed are strictly less than 2.6.0 and 0.14.0 for TF and TF-Probability respectively (TF-Probability version 0.14.0 and above require TensorFlow version equal to or greater than 2.6.0).