### PR TITLE
Quadrature Fourier features

### DIFF
--- a/docs/notebooks/efficient_posterior_sampling.py
+++ b/docs/notebooks/efficient_posterior_sampling.py
@@ -98,7 +98,7 @@ num_experiment_runs = 4  # number of experiment repetitions (64 in the paper)
 num_input_dimensions = [2, 4, 8]  # number of input dimensions
 train_sample_exponents = [2, 4, 6, 8, 10]  # num_train_samples = 2 ** train_sample_exponents
 num_train_samples = [2 ** train_sample_exponent for train_sample_exponent in train_sample_exponents]
-num_components = [
+num_features = [
     1024,
     4096,
     16384,
@@ -233,7 +233,7 @@ The core method of the notebook conducts an individual experiment for a specifie
 """
 
 # %%
-def conduct_experiment(num_input_dimensions, num_train_samples, num_components):
+def conduct_experiment(num_input_dimensions, num_train_samples, num_features):
     """
     Compute the log10 Wassertein distance between the weight space approximated GP and the exact GP,
     and between the hybrid-rule approximated GP and the exact GP.
@@ -247,7 +247,7 @@ def conduct_experiment(num_input_dimensions, num_train_samples, num_components):
     lengthscale = (
         num_input_dimensions / 100.0
     ) ** 0.5  # adjust kernel lengthscale to the number of input dims
-    num_features = num_train_samples + num_components
+    num_features = num_train_samples + num_features
 
     # exact kernel
     exact_kernel = kernel_class(lengthscales=lengthscale)
@@ -255,7 +255,7 @@ def conduct_experiment(num_input_dimensions, num_train_samples, num_components):
     # weight space approximated kernel
     feature_functions = RandomFourierFeaturesCosine(
         kernel=kernel_class(lengthscales=lengthscale),
-        n_components=num_components,
+        n_components=num_features,
         dtype=default_float(),
     )
     feature_coefficients = np.ones((num_features, 1), dtype=default_float())
@@ -327,7 +327,7 @@ This helper function repeats an individual experiment several times and returns 
 """
 
 # %%
-def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples, num_components):
+def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples, num_features):
     """
     Conduct the experiment as specified above `num_experiment_runs` times and identify the quartiles for
     the log10 Wassertein distance between the weight space approximated GP and the exact GP,
@@ -347,7 +347,7 @@ def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples
         log10_ws_dist_weight, log10_ws_dist_hybrid = conduct_experiment(
             num_input_dimensions=num_input_dimensions,
             num_train_samples=num_train_samples,
-            num_components=num_components,
+            num_features=num_features,
         )
         list_of_log10_ws_dist_weight.append(log10_ws_dist_weight)
         list_of_log10_ws_dist_hybrid.append(log10_ws_dist_hybrid)
@@ -363,7 +363,7 @@ Since we conduct different experiments with different training data sizes, we ne
 """
 
 # %%
-def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_components):
+def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_features):
     """
     Conduct the experiment as specified above for different training dataset sizes and store the results in lists.
 
@@ -383,13 +383,13 @@ def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_
         ) = conduct_experiment_for_multiple_runs(
             num_input_dimensions=num_input_dimensions,
             num_train_samples=nts,
-            num_components=num_components,
+            num_features=num_features,
         )
         print(
             "Completed for num input dims = "
             + str(num_input_dimensions)
             + " and feature param = "
-            + str(num_components)
+            + str(num_features)
             + " and num train samples = "
             + str(nts)
         )
@@ -420,9 +420,9 @@ def conduct_experiment_for_different_num_features(num_input_dimensions):
         []
     )  # for the analytic solution using the weight space approximated kernel
     list_of_hybrid_results = []  # for the hybrid-rule approximation
-    for nf in num_components:
+    for nf in num_features:
         weight_results, hybrid_results = conduct_experiment_for_different_train_data_sizes(
-            num_input_dimensions=num_input_dimensions, num_components=nf
+            num_input_dimensions=num_input_dimensions, num_features=nf
         )
         print()
         list_of_weight_results.append(weight_results)
@@ -454,7 +454,7 @@ for i in range(
 
     # plot the results for the analytic solution using the weight space approximated kernel
     colors = ["bisque", "orange", "peru"]
-    assert len(colors) == len(num_components), "Number of colors must equal the number of features!"
+    assert len(colors) == len(num_features), "Number of colors must equal the number of features!"
     for j in range(len(weight_results)):
         weight_result = weight_results[j]
         axs[i].fill_between(
@@ -465,7 +465,7 @@ for i in range(
 
     # plot the results for the hybrid-rule approximation
     colors = ["lightblue", "blue", "darkblue"]
-    assert len(colors) == len(num_components), "Number of colors must equal the number of features!"
+    assert len(colors) == len(num_features), "Number of colors must equal the number of features!"
     for j in range(len(hybrid_results)):
         hybrid_result = hybrid_results[j]
         axs[i].fill_between(

--- a/docs/notebooks/efficient_posterior_sampling.py
+++ b/docs/notebooks/efficient_posterior_sampling.py
@@ -62,7 +62,7 @@ $$\textbf{f}^\star \approx \boldsymbol{\Phi}^\star \textbf{w} + \textbf{K}_{\tex
 
 that combines both feature approximations and exact kernel evaluations from the Matheron function and weight space approximation formulas above.
 
-The subsequent experiments demonstrate the qualitative efficiency of the hybrid rule when compared to the vanilla Matheron weight space approximation, in terms of the Wasserstein distance to the exact posterior GP. To conduct these experiments, the required classes in `gpflux` are `RandomFourierFeatures`, to approximate a stationary kernel with finitely many random Fourier features $\phi_d(\cdot)$ according to Bochner's theorem and following Rahimi and Recht "Random features for large-scale kernel machines" (NeurIPS, 2007), and `KernelWithFeatureDecomposition`, to approximate a kernel with a specified set of feature functions.
+The subsequent experiments demonstrate the qualitative efficiency of the hybrid rule when compared to the vanilla Matheron weight space approximation, in terms of the Wasserstein distance to the exact posterior GP. To conduct these experiments, the required classes in `gpflux` are `RandomFourierFeaturesCosine`, to approximate a stationary kernel with finitely many random Fourier features $\phi_d(\cdot)$ according to Bochner's theorem and following Rahimi and Recht "Random features for large-scale kernel machines" (NeurIPS, 2007), and `KernelWithFeatureDecomposition`, to approximate a kernel with a specified set of feature functions.
 """
 
 # %%
@@ -79,7 +79,7 @@ from gpflow.config import default_float
 from gpflow.kernels import RBF, Matern52
 from gpflow.models import GPR
 
-from gpflux.layers.basis_functions.random_fourier_features import RandomFourierFeatures
+from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine
 from gpflux.sampling.kernel_with_feature_decomposition import KernelWithFeatureDecomposition
 
 # %% [markdown]
@@ -253,9 +253,9 @@ def conduct_experiment(num_input_dimensions, num_train_samples, num_features):
     exact_kernel = kernel_class(lengthscales=lengthscale)
 
     # weight space approximated kernel
-    feature_functions = RandomFourierFeatures(
+    feature_functions = RandomFourierFeaturesCosine(
         kernel=kernel_class(lengthscales=lengthscale),
-        output_dim=num_features,
+        n_components=num_features,
         dtype=default_float(),
     )
     feature_coefficients = np.ones((num_features, 1), dtype=default_float())

--- a/docs/notebooks/efficient_posterior_sampling.py
+++ b/docs/notebooks/efficient_posterior_sampling.py
@@ -98,7 +98,7 @@ num_experiment_runs = 4  # number of experiment repetitions (64 in the paper)
 num_input_dimensions = [2, 4, 8]  # number of input dimensions
 train_sample_exponents = [2, 4, 6, 8, 10]  # num_train_samples = 2 ** train_sample_exponents
 num_train_samples = [2 ** train_sample_exponent for train_sample_exponent in train_sample_exponents]
-num_features = [
+num_components = [
     1024,
     4096,
     16384,
@@ -233,7 +233,7 @@ The core method of the notebook conducts an individual experiment for a specifie
 """
 
 # %%
-def conduct_experiment(num_input_dimensions, num_train_samples, num_features):
+def conduct_experiment(num_input_dimensions, num_train_samples, num_components):
     """
     Compute the log10 Wassertein distance between the weight space approximated GP and the exact GP,
     and between the hybrid-rule approximated GP and the exact GP.
@@ -247,7 +247,7 @@ def conduct_experiment(num_input_dimensions, num_train_samples, num_features):
     lengthscale = (
         num_input_dimensions / 100.0
     ) ** 0.5  # adjust kernel lengthscale to the number of input dims
-    num_features = num_train_samples + num_features
+    num_features = num_train_samples + num_components
 
     # exact kernel
     exact_kernel = kernel_class(lengthscales=lengthscale)
@@ -255,7 +255,7 @@ def conduct_experiment(num_input_dimensions, num_train_samples, num_features):
     # weight space approximated kernel
     feature_functions = RandomFourierFeaturesCosine(
         kernel=kernel_class(lengthscales=lengthscale),
-        n_components=num_features,
+        n_components=num_components,
         dtype=default_float(),
     )
     feature_coefficients = np.ones((num_features, 1), dtype=default_float())
@@ -327,7 +327,7 @@ This helper function repeats an individual experiment several times and returns 
 """
 
 # %%
-def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples, num_features):
+def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples, num_components):
     """
     Conduct the experiment as specified above `num_experiment_runs` times and identify the quartiles for
     the log10 Wassertein distance between the weight space approximated GP and the exact GP,
@@ -347,7 +347,7 @@ def conduct_experiment_for_multiple_runs(num_input_dimensions, num_train_samples
         log10_ws_dist_weight, log10_ws_dist_hybrid = conduct_experiment(
             num_input_dimensions=num_input_dimensions,
             num_train_samples=num_train_samples,
-            num_features=num_features,
+            num_components=num_components,
         )
         list_of_log10_ws_dist_weight.append(log10_ws_dist_weight)
         list_of_log10_ws_dist_hybrid.append(log10_ws_dist_hybrid)
@@ -363,7 +363,7 @@ Since we conduct different experiments with different training data sizes, we ne
 """
 
 # %%
-def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_features):
+def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_components):
     """
     Conduct the experiment as specified above for different training dataset sizes and store the results in lists.
 
@@ -383,13 +383,13 @@ def conduct_experiment_for_different_train_data_sizes(num_input_dimensions, num_
         ) = conduct_experiment_for_multiple_runs(
             num_input_dimensions=num_input_dimensions,
             num_train_samples=nts,
-            num_features=num_features,
+            num_components=num_components,
         )
         print(
             "Completed for num input dims = "
             + str(num_input_dimensions)
             + " and feature param = "
-            + str(num_features)
+            + str(num_components)
             + " and num train samples = "
             + str(nts)
         )
@@ -420,9 +420,9 @@ def conduct_experiment_for_different_num_features(num_input_dimensions):
         []
     )  # for the analytic solution using the weight space approximated kernel
     list_of_hybrid_results = []  # for the hybrid-rule approximation
-    for nf in num_features:
+    for nf in num_components:
         weight_results, hybrid_results = conduct_experiment_for_different_train_data_sizes(
-            num_input_dimensions=num_input_dimensions, num_features=nf
+            num_input_dimensions=num_input_dimensions, num_components=nf
         )
         print()
         list_of_weight_results.append(weight_results)
@@ -454,7 +454,7 @@ for i in range(
 
     # plot the results for the analytic solution using the weight space approximated kernel
     colors = ["bisque", "orange", "peru"]
-    assert len(colors) == len(num_features), "Number of colors must equal the number of features!"
+    assert len(colors) == len(num_components), "Number of colors must equal the number of features!"
     for j in range(len(weight_results)):
         weight_result = weight_results[j]
         axs[i].fill_between(
@@ -465,7 +465,7 @@ for i in range(
 
     # plot the results for the hybrid-rule approximation
     colors = ["lightblue", "blue", "darkblue"]
-    assert len(colors) == len(num_features), "Number of colors must equal the number of features!"
+    assert len(colors) == len(num_components), "Number of colors must equal the number of features!"
     for j in range(len(hybrid_results)):
         hybrid_result = hybrid_results[j]
         axs[i].fill_between(

--- a/docs/notebooks/efficient_sampling.py
+++ b/docs/notebooks/efficient_sampling.py
@@ -36,7 +36,7 @@ import gpflux
 
 from gpflow.config import default_float
 
-from gpflux.layers.basis_functions.random_fourier_features import RandomFourierFeatures
+from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine
 from gpflux.sampling import KernelWithFeatureDecomposition
 from gpflux.models.deep_gp import sample_dgp
 
@@ -71,7 +71,7 @@ inducing_variable = gpflow.inducing_variables.InducingPoints(Z)
 gpflow.utilities.set_trainable(inducing_variable, False)
 
 num_rff = 1000
-eigenfunctions = RandomFourierFeatures(kernel, num_rff, dtype=default_float())
+eigenfunctions = RandomFourierFeaturesCosine(kernel, num_rff, dtype=default_float())
 eigenvalues = np.ones((num_rff, 1), dtype=default_float())
 kernel_with_features = KernelWithFeatureDecomposition(kernel, eigenfunctions, eigenvalues)
 

--- a/docs/notebooks/weight_space_approximation.py
+++ b/docs/notebooks/weight_space_approximation.py
@@ -42,7 +42,7 @@ where we assume $p(\textbf{w})$ to be a standard normal multivariate prior and $
 
 The advantage of expressing a Gaussian process in weight space is that functions are represented as weight vectors $\textbf{w}$ (rather than actual functions $f(\cdot)$) from which samples can be obtained a priori without knowing where the function should be evaluated. When expressing a Gaussian process in function space view the latter is not possible, i.e. a function $f(\cdot)$ cannot be sampled without knowing where to evaluate the function, namely at $\{X_{n^\star}^\star\}_{n^\star=1,...,N^\star}$. Weight space approximated Gaussian processes therefore hold the potential to sample efficiently from Gaussian process posteriors, which is desirable in vanilla supervised learning but also in domains such as Bayesian optimisation or model-based reinforcement learning.
 
-In the following example, we compare a weight space approximated GPR model (WSA model) with both a proper GPR model and a sparse variational Gaussian Process model (SVGP). GPR models and SVGP models are implemented in `gpflow`, but the two necessary ingredients for building the WSA model are part of `gpflux`: these are random Fourier feature functions via the `RandomFourierFeatures` class, and approximate kernels based on Bochner's theorem (or any other theorem that approximates a kernel with a finite number of feature functions, e.g. Mercer) via the `KernelWithFeatureDecomposition` class.
+In the following example, we compare a weight space approximated GPR model (WSA model) with both a proper GPR model and a sparse variational Gaussian Process model (SVGP). GPR models and SVGP models are implemented in `gpflow`, but the two necessary ingredients for building the WSA model are part of `gpflux`: these are random Fourier feature functions via the `RandomFourierFeaturesCosine` class, and approximate kernels based on Bochner's theorem (or any other theorem that approximates a kernel with a finite number of feature functions, e.g. Mercer) via the `KernelWithFeatureDecomposition` class.
 """
 
 # %%
@@ -61,7 +61,7 @@ from gpflow.kernels import RBF, Matern52
 from gpflow.likelihoods import Gaussian
 from gpflow.inducing_variables import InducingPoints
 
-from gpflux.layers.basis_functions.random_fourier_features import RandomFourierFeatures
+from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine
 from gpflux.sampling.kernel_with_feature_decomposition import KernelWithFeatureDecomposition
 
 # %% [markdown]
@@ -77,7 +77,7 @@ The only aspect that is different across both experimental settings is the numbe
 # experiment parameters that are the same for both sets of experiments
 X_interval = [0.14, 0.5]  # interval where training points live
 lengthscale = 0.1  # lengthscale for the kernel (which is not learned in all experiments, the kernel variance is 1)
-number_of_basis_functions = 2000  # number of basis functions for weight-space approximated kernels
+number_of_features = 2000  # number of basis functions for weight-space approximated kernels
 noise_variance = 1e-3  # noise variance of the likelihood (which is not learned in all experiments)
 number_of_test_samples = 1024  # number of evaluation points for prediction
 number_of_function_samples = (
@@ -264,12 +264,12 @@ for experiment in range(len(number_of_train_samples)):
     )
 
     # create exact GPR model with weight-space approximated kernel (WSA model)
-    feature_functions = RandomFourierFeatures(
+    feature_functions = RandomFourierFeaturesCosine(
         kernel=kernel_class(lengthscales=lengthscale),
-        output_dim=number_of_basis_functions,
+        n_components=number_of_features,
         dtype=default_float(),
     )
-    feature_coefficients = np.ones((number_of_basis_functions, 1), dtype=default_float())
+    feature_coefficients = np.ones((number_of_features, 1), dtype=default_float())
     kernel = KernelWithFeatureDecomposition(
         kernel=None, feature_functions=feature_functions, feature_coefficients=feature_coefficients
     )

--- a/gpflux/layers/basis_functions/fourier_features/__init__.py
+++ b/gpflux/layers/basis_functions/fourier_features/__init__.py
@@ -23,3 +23,5 @@ from gpflux.layers.basis_functions.fourier_features.random import (
     RandomFourierFeatures,
     RandomFourierFeaturesCosine,
 )
+
+__all__ = ["QuadratureFourierFeatures", "RandomFourierFeatures", "RandomFourierFeaturesCosine"]

--- a/gpflux/layers/basis_functions/fourier_features/__init__.py
+++ b/gpflux/layers/basis_functions/fourier_features/__init__.py
@@ -14,5 +14,12 @@
 # limitations under the License.
 #
 """
-Basis functions.
+A kernel's features for efficient sampling, used by
+:class:`gpflux.sampling.KernelWithFeatureDecomposition`
 """
+
+from gpflux.layers.basis_functions.fourier_features.quadrature import QuadratureFourierFeatures
+from gpflux.layers.basis_functions.fourier_features.random import (
+    RandomFourierFeatures,
+    RandomFourierFeaturesCosine,
+)

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -1,0 +1,83 @@
+from abc import ABC, abstractmethod
+from typing import Mapping
+
+import tensorflow as tf
+
+import gpflow
+from gpflow.base import TensorType
+
+from gpflux.types import ShapeType
+
+
+class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
+    def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
+        """
+        :param kernel: kernel to approximate using a set of random features.
+        :param output_dim: total number of basis functions used to approximate
+            the kernel.
+        """
+        super().__init__(**kwargs)
+        self.kernel = kernel
+        self.n_components = n_components  # M: number of Monte Carlo samples
+        if kwargs.get("input_dim", None):
+            self._input_dim = kwargs["input_dim"]
+            self.build(tf.TensorShape([self._input_dim]))
+        else:
+            self._input_dim = None
+
+    def call(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Evaluate the basis functions at ``inputs``.
+
+        :param inputs: The evaluation points, a tensor with the shape ``[N, D]``.
+
+        :return: A tensor with the shape ``[N, M]``.
+        """
+        const = self._compute_constant()
+        bases = self._compute_bases(inputs)
+        output = const * bases
+        tf.ensure_shape(output, self.compute_output_shape(inputs.shape))
+        return output
+
+    def compute_output_shape(self, input_shape: ShapeType) -> tf.TensorShape:
+        """
+        Computes the output shape of the layer.
+        See `tf.keras.layers.Layer.compute_output_shape()
+        <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#compute_output_shape>`_.
+        """
+        # TODO: Keras docs say "If the layer has not been built, this method
+        # will call `build` on the layer." -- do we need to do so?
+        tensor_shape = tf.TensorShape(input_shape).with_rank(2)
+        output_dim = self._compute_output_dim(input_shape)
+        return tensor_shape[:-1].concatenate(output_dim)
+
+    def get_config(self) -> Mapping:
+        """
+        Returns the config of the layer.
+        See `tf.keras.layers.Layer.get_config()
+        <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#get_config>`_.
+        """
+        config = super().get_config()
+        config.update(
+            {"kernel": self.kernel, "n_components": self.n_components, "input_dim": self._input_dim}
+        )
+
+        return config
+
+    @abstractmethod
+    def _compute_output_dim(self, input_shape: ShapeType) -> int:
+        pass
+
+    @abstractmethod
+    def _compute_constant(self) -> tf.Tensor:
+        """
+        Compute normalizing constant for basis functions.
+        """
+        pass
+
+    @abstractmethod
+    def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Compute basis functions.
+        """
+        pass

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -33,8 +33,9 @@ class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
 
         :return: A tensor with the shape ``[N, M]``.
         """
+        X = tf.divide(inputs, self.kernel.lengthscales)  # [N, D]
         const = self._compute_constant()
-        bases = self._compute_bases(inputs)
+        bases = self._compute_bases(X)
         output = const * bases
         tf.ensure_shape(output, self.compute_output_shape(inputs.shape))
         return output

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -29,13 +29,13 @@ from gpflux.types import ShapeType
 class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
     def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
         """
-        :param kernel: kernel to approximate using a set of random features.
-        :param output_dim: total number of basis functions used to approximate
-            the kernel.
+        :param kernel: kernel to approximate using a set of Fourier bases.
+        :param n_components: number of components (e.g. Monte Carlo samples, 
+            quadrature nodes, etc.) used to numerically approximate the kernel.
         """
         super(FourierFeaturesBase, self).__init__(**kwargs)
         self.kernel = kernel
-        self.n_components = n_components  # M: number of Monte Carlo samples
+        self.n_components = n_components
         if kwargs.get("input_dim", None):
             self._input_dim = kwargs["input_dim"]
             self.build(tf.TensorShape([self._input_dim]))

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2021 The GPflux Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" Shared functionality for stationary kernel basis functions. """
+
 from abc import ABC, abstractmethod
 from typing import Mapping
 

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -30,7 +30,7 @@ class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
     def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
         """
         :param kernel: kernel to approximate using a set of Fourier bases.
-        :param n_components: number of components (e.g. Monte Carlo samples, 
+        :param n_components: number of components (e.g. Monte Carlo samples,
             quadrature nodes, etc.) used to numerically approximate the kernel.
         """
         super(FourierFeaturesBase, self).__init__(**kwargs)

--- a/gpflux/layers/basis_functions/fourier_features/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/base.py
@@ -16,7 +16,7 @@ class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
         :param output_dim: total number of basis functions used to approximate
             the kernel.
         """
-        super().__init__(**kwargs)
+        super(FourierFeaturesBase, self).__init__(**kwargs)
         self.kernel = kernel
         self.n_components = n_components  # M: number of Monte Carlo samples
         if kwargs.get("input_dim", None):
@@ -57,7 +57,7 @@ class FourierFeaturesBase(ABC, tf.keras.layers.Layer):
         See `tf.keras.layers.Layer.get_config()
         <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#get_config>`_.
         """
-        config = super().get_config()
+        config = super(FourierFeaturesBase, self).get_config()
         config.update(
             {"kernel": self.kernel, "n_components": self.n_components, "input_dim": self._input_dim}
         )

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -20,6 +20,8 @@ from typing import Mapping
 import tensorflow as tf
 
 import gpflow
+import warnings
+
 from gpflow.base import TensorType
 from gpflow.quadrature.gauss_hermite import ndgh_points_and_weights
 
@@ -34,6 +36,9 @@ from gpflux.types import ShapeType
 class QuadratureFourierFeatures(FourierFeaturesBase):
     def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
         assert isinstance(kernel, QFF_SUPPORTED_KERNELS), "Unsupported Kernel"
+        if tf.reduce_any(tf.less(kernel.lengthscales, 1e-1)):
+            warnings.warn("Quadrature Fourier feature approximation of kernels "
+                          "with small lengthscale lead to unexpected behaviors!")
         super(QuadratureFourierFeatures, self).__init__(kernel, n_components, **kwargs)
 
     def build(self, input_shape: ShapeType) -> None:

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -43,23 +43,24 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
         <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#build>`_.
         """
         input_dim = input_shape[-1]
-        abscissa_value, weights_value = ndgh_points_and_weights(
+        abscissa_value, omegas_value = ndgh_points_and_weights(
             dim=input_dim, n_gh=self.n_components
         )
+        omegas_value = tf.squeeze(omegas_value, axis=-1)
 
         # Quadrature node points
-        self.abscissa = tf.Variable(initial_value=abscissa_value, trainable=False)
+        self.abscissa = tf.Variable(initial_value=abscissa_value, trainable=False)  # (M^D, D)
         # Gauss-Hermite weights (not to be confused with random Fourier feature
         # weights or NN weights)
-        self.weights = tf.Variable(initial_value=weights_value, trainable=False)
-        super().build(input_shape)
+        self.omegas = tf.Variable(initial_value=omegas_value, trainable=False)  # (M^D,)
+        super(QuadratureFourierFeatures, self).build(input_shape)
 
     def _compute_output_dim(self, input_shape: ShapeType) -> int:
         input_dim = input_shape[-1]
         return 2 * self.n_components ** input_dim
 
     def _compute_constant(self) -> tf.Tensor:
-        return tf.tile(tf.sqrt(self.kernel.variance * self.weights), multiples=[2])
+        return tf.tile(tf.sqrt(self.kernel.variance * self.omegas), multiples=[2])
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
         return _bases_concat(inputs, self.abscissa, lengthscales=self.kernel.lengthscales)

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -50,9 +50,8 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
 
         # Quadrature node points
         self.abscissa = tf.Variable(initial_value=abscissa_value, trainable=False)  # (M^D, D)
-        # Gauss-Hermite weights (not to be confused with random Fourier feature
-        # weights or NN weights)
-        self.omegas = tf.Variable(initial_value=omegas_value, trainable=False)  # (M^D,)
+        # Gauss-Hermite weights
+        self.factors = tf.Variable(initial_value=omegas_value, trainable=False)  # (M^D,)
         super(QuadratureFourierFeatures, self).build(input_shape)
 
     def _compute_output_dim(self, input_shape: ShapeType) -> int:
@@ -60,7 +59,7 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
         return 2 * self.n_components ** input_dim
 
     def _compute_constant(self) -> tf.Tensor:
-        return tf.tile(tf.sqrt(self.kernel.variance * self.omegas), multiples=[2])
+        return tf.tile(tf.sqrt(self.kernel.variance * self.factors), multiples=[2])
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
         return _bases_concat(inputs, self.abscissa)

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -15,13 +15,12 @@
 #
 """ A kernel's features and coefficients using quadrature Fourier features (QFF). """
 
+import warnings
 from typing import Mapping
 
 import tensorflow as tf
 
 import gpflow
-import warnings
-
 from gpflow.base import TensorType
 from gpflow.quadrature.gauss_hermite import ndgh_points_and_weights
 
@@ -37,8 +36,10 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
     def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
         assert isinstance(kernel, QFF_SUPPORTED_KERNELS), "Unsupported Kernel"
         if tf.reduce_any(tf.less(kernel.lengthscales, 1e-1)):
-            warnings.warn("Quadrature Fourier feature approximation of kernels "
-                          "with small lengthscale lead to unexpected behaviors!")
+            warnings.warn(
+                "Quadrature Fourier feature approximation of kernels "
+                "with small lengthscale lead to unexpected behaviors!"
+            )
         super(QuadratureFourierFeatures, self).__init__(kernel, n_components, **kwargs)
 
     def build(self, input_shape: ShapeType) -> None:

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -63,4 +63,4 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
         return tf.tile(tf.sqrt(self.kernel.variance * self.omegas), multiples=[2])
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
-        return _bases_concat(inputs, self.abscissa, lengthscales=self.kernel.lengthscales)
+        return _bases_concat(inputs, self.abscissa)

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2021 The GPflux Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" A kernel's features and coefficients using quadrature Fourier features (QFF). """
+
+from typing import Mapping
+
+import tensorflow as tf
+
+import gpflow
+from gpflow.base import TensorType
+from gpflow.quadrature.gauss_hermite import ndgh_points_and_weights
+
+from gpflux.layers.basis_functions.fourier_features.utils import (
+    QFF_SUPPORTED_KERNELS,
+    _mapping_concat,
+)
+from gpflux.types import ShapeType
+
+
+class QuadratureFourierFeatures(tf.keras.layers.Layer):
+    def __init__(self, kernel: gpflow.kernels.Kernel, n_components: int, **kwargs: Mapping):
+        """
+        :param kernel: kernel to approximate using a set of random features.
+        :param output_dim: total number of basis functions used to approximate
+            the kernel.
+        """
+        super().__init__(**kwargs)
+
+        assert isinstance(kernel, QFF_SUPPORTED_KERNELS), "Unsupported Kernel"
+        self.kernel = kernel
+        self.n_components = n_components  # M: number of quadrature points
+        if kwargs.get("input_dim", None):
+            self._input_dim = kwargs["input_dim"]
+            self.build(tf.TensorShape([self._input_dim]))
+        else:
+            self._input_dim = None
+
+    def build(self, input_shape: ShapeType) -> None:
+        """
+        Creates the variables of the layer.
+        See `tf.keras.layers.Layer.build()
+        <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#build>`_.
+        """
+        input_dim = input_shape[-1]
+        abscissa_value, weights_value = ndgh_points_and_weights(
+            dim=input_dim, n_gh=self.n_components
+        )
+
+        # Quadrature node points
+        self.abscissa = tf.Variable(initial_value=abscissa_value, trainable=False)
+        # Gauss-Hermite weights (not to be confused with random Fourier feature
+        # weights or NN weights)
+        self.weights = tf.Variable(initiial_value=weights_value, trainable=False)
+        super().build(input_shape)
+
+    def compute_output_shape(self, input_shape: ShapeType) -> tf.TensorShape:
+        """
+        Computes the output shape of the layer.
+        See `tf.keras.layers.Layer.compute_output_shape()
+        <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#compute_output_shape>`_.
+        """
+        # TODO: Keras docs say "If the layer has not been built, this method
+        # will call `build` on the layer." -- do we need to do so?
+        input_dim = input_shape[-1]
+        output_dim = 2 * self.n_components ** input_dim
+        tensor_shape = tf.TensorShape(input_shape).with_rank(2)
+        return tensor_shape[:-1].concatenate(output_dim)
+
+    def get_config(self) -> Mapping:
+        """
+        Returns the config of the layer.
+        See `tf.keras.layers.Layer.get_config()
+        <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#get_config>`_.
+        """
+        config = super().get_config()
+        config.update(
+            {"kernel": self.kernel, "n_components": self.n_components, "input_dim": self._input_dim}
+        )
+
+        return config
+
+    def call(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Evaluate the basis functions at ``inputs``.
+
+        :param inputs: The evaluation points, a tensor with the shape ``[N, D]``.
+
+        :return: A tensor with the shape ``[N, 2M^D]``.
+        """
+        const = tf.tile(tf.sqrt(self.kernel.variance * self.weights), multiples=[2])
+        bases = _mapping_concat(inputs, self.abscissa, lengthscales=self.kernel.lengthscales)
+        output = const * bases
+        tf.ensure_shape(output, self.compute_output_shape(inputs.shape))
+        return output

--- a/gpflux/layers/basis_functions/fourier_features/quadrature.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature.py
@@ -64,8 +64,18 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
         input_dim = input_shape[-1]
         return 2 * self.n_components ** input_dim
 
-    def _compute_constant(self) -> tf.Tensor:
-        return tf.tile(tf.sqrt(self.kernel.variance * self.factors), multiples=[2])
-
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Compute basis functions.
+
+        :return: A tensor with the shape ``[N, 2M^D]``.
+        """
         return _bases_concat(inputs, self.abscissa)
+
+    def _compute_constant(self) -> tf.Tensor:
+        """
+        Compute normalizing constant for basis functions.
+
+        :return: A tensor with the shape ``[2M^D,]``
+        """
+        return tf.tile(tf.sqrt(self.kernel.variance * self.factors), multiples=[2])

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -67,12 +67,6 @@ class RandomFourierFeaturesBase(FourierFeaturesBase):
             nu = 2.0 * p + 1.0  # degrees of freedom
             return _sample_students_t(nu, shape, dtype)
 
-    def _compute_constant(self) -> tf.Tensor:
-        """
-        Compute normalizing constant for basis functions.
-        """
-        return tf.sqrt(2.0 * self.kernel.variance / self.n_components)
-
 
 class RandomFourierFeatures(RandomFourierFeaturesBase):
     r"""
@@ -113,6 +107,12 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
         return _bases_concat(inputs, self.W, lengthscales=self.kernel.lengthscales)
+
+    def _compute_constant(self) -> tf.Tensor:
+        """
+        Compute normalizing constant for basis functions.
+        """
+        return tf.sqrt(self.kernel.variance / self.n_components)
 
 
 class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
@@ -172,3 +172,9 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
         return _bases_cosine(inputs, self.W, self.b, lengthscales=self.kernel.lengthscales)
+
+    def _compute_constant(self) -> tf.Tensor:
+        """
+        Compute normalizing constant for basis functions.
+        """
+        return tf.sqrt(2.0 * self.kernel.variance / self.n_components)

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -113,11 +113,18 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
         return 2 * self.n_components
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Compute basis functions.
+
+        :return: A tensor with the shape ``[N, 2M]``.
+        """
         return _bases_concat(inputs, self.W)
 
     def _compute_constant(self) -> tf.Tensor:
         """
         Compute normalizing constant for basis functions.
+
+        :return: A tensor with the shape ``[]`` (i.e. a scalar).
         """
         return self.rff_constant(self.kernel.variance, output_dim=2 * self.n_components)
 
@@ -178,10 +185,17 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         return self.n_components
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
+        """
+        Compute basis functions.
+
+        :return: A tensor with the shape ``[N, M]``.
+        """
         return _bases_cosine(inputs, self.W, self.b)
 
     def _compute_constant(self) -> tf.Tensor:
         """
         Compute normalizing constant for basis functions.
+
+        :return: A tensor with the shape ``[]`` (i.e. a scalar).
         """
         return self.rff_constant(self.kernel.variance, output_dim=self.n_components)

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -59,7 +59,6 @@ class RandomFourierFeaturesBase(tf.keras.layers.Layer):
         """
         input_dim = input_shape[-1]
         self._weights_build(input_dim, n_components=self.n_components)
-
         super().build(input_shape)
 
     def _weights_build(self, input_dim: int, n_components: int) -> None:
@@ -206,7 +205,6 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         input_dim = input_shape[-1]
         self._weights_build(input_dim, n_components=self.output_dim)
         self._bias_build(n_components=self.output_dim)
-
         super().build(input_shape)
 
     def _bias_build(self, n_components: int) -> None:

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -105,8 +105,8 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
       where :math:`p(\boldsymbol{\theta})` is the spectral density of the kernel.
 
     At least for the squared exponential kernel, this variant of the feature
-    mapping has more desirable theoretical properties than its cosine-based
-    counterpart :class:`RandomFourierFeaturesCosine` :cite:p:`sutherland2015error`.
+    mapping has more desirable theoretical properties than its counterpart form 
+    from phase-shifted cosines :class:`RandomFourierFeaturesCosine` :cite:p:`sutherland2015error`.
     """
 
     def _compute_output_dim(self, input_shape: ShapeType) -> int:
@@ -149,7 +149,7 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
       where :math:`p(\boldsymbol{\theta})` is the spectral density of the kernel
     - :math:`\tau \sim \mathcal{U}(0, 2\pi)`
 
-    Equivalent to :class:`RandomFourierFeatures` by elementary trignometric identities.
+    Equivalent to :class:`RandomFourierFeatures` by elementary trigonometric identities.
     """
 
     def build(self, input_shape: ShapeType) -> None:

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -203,7 +203,6 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer#build>`_.
         """
         input_dim = input_shape[-1]
-        self._weights_build(input_dim, n_components=self.output_dim)
         self._bias_build(n_components=self.output_dim)
         super().build(input_shape)
 

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -72,7 +72,7 @@ class RandomFourierFeaturesBase(FourierFeaturesBase):
         """
         Normalizing constant for random Fourier features.
         """
-        return tf.sqrt(2.0 * variance / output_dim)
+        return tf.sqrt(tf.math.truediv(2.0 * variance, output_dim))
 
 
 class RandomFourierFeatures(RandomFourierFeaturesBase):
@@ -119,7 +119,7 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
         """
         Compute normalizing constant for basis functions.
         """
-        return self.rff_constant(self.kernel.variance, 2 * self.n_components)
+        return self.rff_constant(self.kernel.variance, output_dim=2.0 * self.n_components)
 
 
 class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
@@ -184,4 +184,4 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         """
         Compute normalizing constant for basis functions.
         """
-        return self.rff_constant(self.kernel.variance, self.n_components)
+        return self.rff_constant(self.kernel.variance, output_dim=self.n_components)

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -105,7 +105,7 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
       where :math:`p(\boldsymbol{\theta})` is the spectral density of the kernel.
 
     At least for the squared exponential kernel, this variant of the feature
-    mapping has more desirable theoretical properties than its counterpart form 
+    mapping has more desirable theoretical properties than its counterpart form
     from phase-shifted cosines :class:`RandomFourierFeaturesCosine` :cite:p:`sutherland2015error`.
     """
 
@@ -119,7 +119,7 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
         """
         Compute normalizing constant for basis functions.
         """
-        return self.rff_constant(self.kernel.variance, output_dim=2.0 * self.n_components)
+        return self.rff_constant(self.kernel.variance, output_dim=2 * self.n_components)
 
 
 class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):

--- a/gpflux/layers/basis_functions/fourier_features/random.py
+++ b/gpflux/layers/basis_functions/fourier_features/random.py
@@ -67,6 +67,13 @@ class RandomFourierFeaturesBase(FourierFeaturesBase):
             nu = 2.0 * p + 1.0  # degrees of freedom
             return _sample_students_t(nu, shape, dtype)
 
+    @staticmethod
+    def rff_constant(variance: TensorType, output_dim: int) -> tf.Tensor:
+        """
+        Normalizing constant for random Fourier features.
+        """
+        return tf.sqrt(2.0 * variance / output_dim)
+
 
 class RandomFourierFeatures(RandomFourierFeaturesBase):
     r"""
@@ -106,13 +113,13 @@ class RandomFourierFeatures(RandomFourierFeaturesBase):
         return 2 * self.n_components
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
-        return _bases_concat(inputs, self.W, lengthscales=self.kernel.lengthscales)
+        return _bases_concat(inputs, self.W)
 
     def _compute_constant(self) -> tf.Tensor:
         """
         Compute normalizing constant for basis functions.
         """
-        return tf.sqrt(self.kernel.variance / self.n_components)
+        return self.rff_constant(self.kernel.variance, 2 * self.n_components)
 
 
 class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
@@ -171,10 +178,10 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         return self.n_components
 
     def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
-        return _bases_cosine(inputs, self.W, self.b, lengthscales=self.kernel.lengthscales)
+        return _bases_cosine(inputs, self.W, self.b)
 
     def _compute_constant(self) -> tf.Tensor:
         """
         Compute normalizing constant for basis functions.
         """
-        return tf.sqrt(2.0 * self.kernel.variance / self.n_components)
+        return self.rff_constant(self.kernel.variance, self.n_components)

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -25,6 +25,16 @@ from gpflow.base import DType, TensorType
 
 from gpflux.types import ShapeType
 
+QFF_SUPPORTED_KERNELS: Tuple[Type[gpflow.kernels.Stationary], ...] = (
+    gpflow.kernels.SquaredExponential,
+)
+
+"""
+Kernels supported by :class:`RandomFourierFeatures`.
+
+You can build RFF for shift-invariant stationary kernels from which you can
+sample frequencies from their power spectrum, following Bochner's theorem.
+"""
 RFF_SUPPORTED_KERNELS: Tuple[Type[gpflow.kernels.Stationary], ...] = (
     gpflow.kernels.SquaredExponential,
     gpflow.kernels.Matern12,
@@ -78,36 +88,36 @@ def _mapping_cosine(
     X: TensorType,
     W: TensorType,
     b: TensorType,
-    variance: TensorType,
+    # variance: TensorType,
     lengthscales: TensorType,
-    n_components: int,
+    # n_components: int,
 ) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    constant = tf.sqrt(2.0 * variance / n_components)
+    # constant = tf.sqrt(2.0 * variance / n_components)
     X_scaled = tf.divide(X, lengthscales)  # [N, D]
     proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M]
     bases = tf.cos(proj + b)  # [N, M]
-    return constant * bases  # [N, M]
+    return bases
 
 
 def _mapping_concat(
     X: TensorType,
     W: TensorType,
-    variance: TensorType,
+    # variance: TensorType,
     lengthscales: TensorType,
-    n_components: int,
+    # n_components: int,
 ) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    constant = tf.sqrt(2.0 * variance / n_components)
+    # constant = tf.sqrt(2.0 * variance / n_components)
     X_scaled = tf.divide(X, lengthscales)  # [N, D]
-    proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M // 2]
-    bases = tf.concat([tf.sin(proj), tf.cos(proj)], axis=-1)  # [N, M]
-    return constant * bases  # [N, M]
+    proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M]
+    bases = tf.concat([tf.sin(proj), tf.cos(proj)], axis=-1)  # [N, 2M]
+    return bases

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -84,34 +84,21 @@ def _sample_students_t(nu: float, shape: ShapeType, dtype: DType) -> TensorType:
     return students_t_rvs
 
 
-def _bases_cosine(
-    X: TensorType,
-    W: TensorType,
-    b: TensorType,
-    lengthscales: TensorType,
-) -> TensorType:
+def _bases_cosine(X: TensorType, W: TensorType, b: TensorType) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    X_scaled = tf.divide(X, lengthscales)  # [N, D]
-    proj = tf.matmul(X_scaled, W, transpose_b=True) + b  # [N, M]
-    bases = tf.cos(proj)  # [N, M]
-    return bases
+    proj = tf.matmul(X, W, transpose_b=True) + b  # [N, M]
+    return tf.cos(proj)  # [N, M]
 
 
-def _bases_concat(
-    X: TensorType,
-    W: TensorType,
-    lengthscales: TensorType,
-) -> TensorType:
+def _bases_concat(X: TensorType, W: TensorType) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    X_scaled = tf.divide(X, lengthscales)  # [N, D]
-    proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M]
-    bases = tf.concat([tf.sin(proj), tf.cos(proj)], axis=-1)  # [N, 2M]
-    return bases
+    proj = tf.matmul(X, W, transpose_b=True)  # [N, M]
+    return tf.concat([tf.sin(proj), tf.cos(proj)], axis=-1)  # [N, 2M]

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -84,7 +84,7 @@ def _sample_students_t(nu: float, shape: ShapeType, dtype: DType) -> TensorType:
     return students_t_rvs
 
 
-def _mapping_cosine(
+def _bases_cosine(
     X: TensorType,
     W: TensorType,
     b: TensorType,
@@ -101,7 +101,7 @@ def _mapping_cosine(
     return bases
 
 
-def _mapping_concat(
+def _bases_concat(
     X: TensorType,
     W: TensorType,
     lengthscales: TensorType,

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -25,8 +25,8 @@ from gpflow.base import DType, TensorType
 
 from gpflux.types import ShapeType
 
-""" 
-Kernels supported by :class:`QuadratureFourierFeatures`. 
+"""
+Kernels supported by :class:`QuadratureFourierFeatures`.
 
 Currently we only support the :class:`gpflow.kernels.SquaredExponential` kernel.
 For Matern kernels use :class:`RandomFourierFeatures`.

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -88,35 +88,29 @@ def _mapping_cosine(
     X: TensorType,
     W: TensorType,
     b: TensorType,
-    # variance: TensorType,
     lengthscales: TensorType,
-    # n_components: int,
 ) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    # constant = tf.sqrt(2.0 * variance / n_components)
     X_scaled = tf.divide(X, lengthscales)  # [N, D]
-    proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M]
-    bases = tf.cos(proj + b)  # [N, M]
+    proj = tf.matmul(X_scaled, W, transpose_b=True) + b  # [N, M]
+    bases = tf.cos(proj)  # [N, M]
     return bases
 
 
 def _mapping_concat(
     X: TensorType,
     W: TensorType,
-    # variance: TensorType,
     lengthscales: TensorType,
-    # n_components: int,
 ) -> TensorType:
     """
     Feature map for random Fourier features (RFF) as originally prescribed
     by Rahimi & Recht, 2007 :cite:p:`rahimi2007random`.
     See also :cite:p:`sutherland2015error` for additional details.
     """
-    # constant = tf.sqrt(2.0 * variance / n_components)
     X_scaled = tf.divide(X, lengthscales)  # [N, D]
     proj = tf.matmul(X_scaled, W, transpose_b=True)  # [N, M]
     bases = tf.concat([tf.sin(proj), tf.cos(proj)], axis=-1)  # [N, 2M]

--- a/gpflux/layers/basis_functions/fourier_features/utils.py
+++ b/gpflux/layers/basis_functions/fourier_features/utils.py
@@ -25,6 +25,12 @@ from gpflow.base import DType, TensorType
 
 from gpflux.types import ShapeType
 
+""" 
+Kernels supported by :class:`QuadratureFourierFeatures`. 
+
+Currently we only support the :class:`gpflow.kernels.SquaredExponential` kernel.
+For Matern kernels use :class:`RandomFourierFeatures`.
+"""
 QFF_SUPPORTED_KERNELS: Tuple[Type[gpflow.kernels.Stationary], ...] = (
     gpflow.kernels.SquaredExponential,
 )

--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -40,7 +40,7 @@ def _variance_fixture(request):
     return request.param
 
 
-@pytest.fixture(name="lengthscale", params=[0.1, 1.0, 5.0])
+@pytest.fixture(name="lengthscale", params=[0.75, 1.0, 5.0])
 def _lengthscale_fixture(request):
     return request.param
 
@@ -66,12 +66,12 @@ def test_quadrature_fourier_features_can_approximate_kernel_multidim(
     kernel_cls, variance, lengthscale, n_dims
 ):
 
-    n_components = 60
+    n_components = 128
 
     x_rows = 20
     y_rows = 30
     # ARD
-    lengthscales = np.random.rand(n_dims) * lengthscale
+    lengthscales = np.random.uniform(low=0.75, size=n_dims) * lengthscale
 
     kernel = kernel_cls(variance=variance, lengthscales=lengthscales)
     fourier_features = QuadratureFourierFeatures(kernel, n_components, dtype=tf.float64)
@@ -85,7 +85,7 @@ def test_quadrature_fourier_features_can_approximate_kernel_multidim(
 
     actual_kernel_matrix = kernel.K(x, y)
 
-    np.testing.assert_allclose(approx_kernel_matrix, actual_kernel_matrix, atol=5e-2)
+    np.testing.assert_allclose(approx_kernel_matrix, actual_kernel_matrix)
 
 
 def test_fourier_features_shapes(n_components, n_dims, batch_size):

--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -77,6 +77,8 @@ def test_quadrature_fourier_features_can_approximate_kernel_multidim(
     x_rows = 20
     y_rows = 30
     # ARD
+
+    # small lengthscales can lead to large errors in this approximation
     lengthscales = np.random.uniform(low=0.75, size=n_dims) * lengthscale
 
     kernel = kernel_cls(variance=variance, lengthscales=lengthscales)

--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -68,6 +68,10 @@ def test_quadrature_fourier_features_can_approximate_kernel_multidim(
     kernel_cls, variance, lengthscale, n_dims
 ):
 
+    """
+    Compare finite feature approximation to analytical kernel expression.
+    Approximation only holds for large enough lengthscales, as explained in TODO: notebook.
+    """
     n_components = 128
 
     x_rows = 20

--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2021 The GPflux Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+import pytest
+import tensorflow as tf
+from tensorflow.python.keras.testing_utils import layer_test
+from tensorflow.python.keras.utils.kernelized_utils import inner_product
+
+import gpflow
+
+from gpflux.layers.basis_functions.fourier_features import QuadratureFourierFeatures
+from gpflux.layers.basis_functions.fourier_features.utils import QFF_SUPPORTED_KERNELS
+
+
+@pytest.fixture(name="n_dims", params=[1, 2, 3])
+def _n_dims_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="n_components", params=[1, 2, 4, 20])
+def _n_features_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="variance", params=[0.5, 1.0, 2.0])
+def _variance_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="lengthscale", params=[0.1, 1.0, 5.0])
+def _lengthscale_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="batch_size", params=[1, 10])
+def _batch_size_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="kernel_cls", params=list(QFF_SUPPORTED_KERNELS))
+def _kernel_cls_fixture(request):
+    return request.param
+
+
+def test_throw_for_unsupported_kernel():
+    kernel = gpflow.kernels.Constant()
+    with pytest.raises(AssertionError) as excinfo:
+        QuadratureFourierFeatures(kernel, n_components=1)
+    assert "Unsupported Kernel" in str(excinfo.value)
+
+
+def test_quadrature_fourier_features_can_approximate_kernel_multidim(kernel_cls, variance, lengthscale, n_dims):
+
+    n_components = 60
+
+    x_rows = 20
+    y_rows = 30
+    # ARD
+    lengthscales = np.random.rand(n_dims) * lengthscale
+
+    kernel = kernel_cls(variance=variance, lengthscales=lengthscales)
+    fourier_features = QuadratureFourierFeatures(kernel, n_components, dtype=tf.float64)
+
+    x = tf.random.uniform((x_rows, n_dims), dtype=tf.float64)
+    y = tf.random.uniform((y_rows, n_dims), dtype=tf.float64)
+
+    u = fourier_features(x)
+    v = fourier_features(y)
+    approx_kernel_matrix = inner_product(u, v)
+
+    actual_kernel_matrix = kernel.K(x, y)
+
+    np.testing.assert_allclose(approx_kernel_matrix, actual_kernel_matrix, atol=5e-2)
+
+
+def test_fourier_features_shapes(n_components, n_dims, batch_size):
+    input_shape = (batch_size, n_dims)
+    kernel = gpflow.kernels.SquaredExponential()
+    feature_functions = QuadratureFourierFeatures(kernel, n_components, dtype=tf.float64)
+    output_shape = feature_functions.compute_output_shape(input_shape)
+    output_dim = output_shape[-1]
+    assert output_dim == 2*n_components**n_dims
+    features = feature_functions(tf.ones(shape=input_shape))
+    np.testing.assert_equal(features.shape, output_shape)
+
+
+def test_keras_testing_util_layer_test_1D(kernel_cls, batch_size, n_components):
+    kernel = kernel_cls()
+
+    tf.keras.utils.get_custom_objects()["QuadratureFourierFeatures"] = QuadratureFourierFeatures
+    layer_test(
+        QuadratureFourierFeatures,
+        kwargs={
+            "kernel": kernel,
+            "n_components": n_components,
+            "input_dim": 1,
+            "dtype": "float64",
+            "dynamic": True,
+        },
+        input_shape=(batch_size, 1),
+        input_dtype="float64",
+    )
+
+
+def test_keras_testing_util_layer_test_multidim(kernel_cls, batch_size, n_dims, n_components):
+    kernel = kernel_cls()
+
+    tf.keras.utils.get_custom_objects()["QuadratureFourierFeatures"] = QuadratureFourierFeatures
+    layer_test(
+        QuadratureFourierFeatures,
+        kwargs={
+            "kernel": kernel,
+            "n_components": n_components,
+            "input_dim": n_dims,
+            "dtype": "float64",
+            "dynamic": True,
+        },
+        input_shape=(batch_size, n_dims),
+        input_dtype="float64",
+    )

--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -62,7 +62,9 @@ def test_throw_for_unsupported_kernel():
     assert "Unsupported Kernel" in str(excinfo.value)
 
 
-def test_quadrature_fourier_features_can_approximate_kernel_multidim(kernel_cls, variance, lengthscale, n_dims):
+def test_quadrature_fourier_features_can_approximate_kernel_multidim(
+    kernel_cls, variance, lengthscale, n_dims
+):
 
     n_components = 60
 
@@ -92,7 +94,7 @@ def test_fourier_features_shapes(n_components, n_dims, batch_size):
     feature_functions = QuadratureFourierFeatures(kernel, n_components, dtype=tf.float64)
     output_shape = feature_functions.compute_output_shape(input_shape)
     output_dim = output_shape[-1]
-    assert output_dim == 2*n_components**n_dims
+    assert output_dim == 2 * n_components ** n_dims
     features = feature_functions(tf.ones(shape=input_shape))
     np.testing.assert_equal(features.shape, output_shape)
 

--- a/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
+++ b/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
@@ -43,7 +43,7 @@ def _batch_size_fixture(request):
     return request.param
 
 
-@pytest.fixture(name="n_features", params=[2, 4, 16, 128])
+@pytest.fixture(name="n_features", params=[1, 2, 4, 20, 100])
 def _n_features_fixture(request):
     return request.param
 
@@ -53,24 +53,15 @@ def _kernel_class_fixture(request):
     return request.param
 
 
-@pytest.fixture(
-    name="random_feature_class", params=[RandomFourierFeatures, RandomFourierFeaturesCosine]
-)
+@pytest.fixture(name="random_feature_class", params=[RandomFourierFeaturesCosine])
 def _random_feature_class_fixture(request):
     return request.param
-
-
-def test_throw_for_odd_num_features():
-    kernel = gpflow.kernels.Constant()
-    with pytest.raises(AssertionError) as excinfo:
-        RandomFourierFeatures(kernel, output_dim=3)
-    assert "must specify an even number of random features" in str(excinfo.value)
 
 
 def test_throw_for_unsupported_kernel(random_feature_class):
     kernel = gpflow.kernels.Constant()
     with pytest.raises(AssertionError) as excinfo:
-        random_feature_class(kernel, output_dim=2)
+        random_feature_class(kernel, n_components=1)
     assert "Unsupported Kernel" in str(excinfo.value)
 
 
@@ -137,7 +128,7 @@ def test_keras_testing_util_layer_test_1D(kernel_class, batch_size, n_features):
         RandomFourierFeatures,
         kwargs={
             "kernel": kernel,
-            "output_dim": n_features,
+            "n_components": n_features,
             "input_dim": 1,
             "dtype": "float64",
             "dynamic": True,
@@ -155,7 +146,7 @@ def test_keras_testing_util_layer_test_multidim(kernel_class, batch_size, n_dims
         RandomFourierFeatures,
         kwargs={
             "kernel": kernel,
-            "output_dim": n_features,
+            "n_components": n_features,
             "input_dim": n_dims,
             "dtype": "float64",
             "dynamic": True,

--- a/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
+++ b/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
@@ -21,11 +21,11 @@ from tensorflow.python.keras.utils.kernelized_utils import inner_product
 
 import gpflow
 
-from gpflux.layers.basis_functions.random_fourier_features import (
-    RFF_SUPPORTED_KERNELS,
+from gpflux.layers.basis_functions.fourier_features import (
     RandomFourierFeatures,
     RandomFourierFeaturesCosine,
 )
+from gpflux.layers.basis_functions.fourier_features.utils import RFF_SUPPORTED_KERNELS
 
 
 @pytest.fixture(name="n_dims", params=[1, 2, 3, 5, 10, 20])

--- a/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
+++ b/tests/gpflux/layers/basis_functions/test_random_fourier_features.py
@@ -33,6 +33,11 @@ def _n_dims_fixture(request):
     return request.param
 
 
+@pytest.fixture(name="variance", params=[0.5, 1.0, 2.0])
+def _variance_fixture(request):
+    return request.param
+
+
 @pytest.fixture(name="lengthscale", params=[1e-3, 0.1, 1.0, 5.0])
 def _lengthscale_fixture(request):
     return request.param
@@ -53,7 +58,7 @@ def _kernel_cls_fixture(request):
     return request.param
 
 
-@pytest.fixture(name="random_feature_cls", params=[RandomFourierFeatures, 
+@pytest.fixture(name="random_feature_cls", params=[RandomFourierFeatures,
                                                    RandomFourierFeaturesCosine])
 def _random_feature_cls_fixture(request):
     return request.param
@@ -67,15 +72,15 @@ def test_throw_for_unsupported_kernel(random_feature_cls):
 
 
 def test_fourier_features_can_approximate_kernel_multidim(
-    random_feature_cls, kernel_cls, lengthscale, n_dims
+    random_feature_cls, kernel_cls, variance, lengthscale, n_dims
 ):
-    n_components = 10000
+    n_components = 50000
     x_rows = 20
     y_rows = 30
     # ARD
     lengthscales = np.random.rand((n_dims)) * lengthscale
 
-    kernel = kernel_cls(lengthscales=lengthscales)
+    kernel = kernel_cls(variance=variance, lengthscales=lengthscales)
     fourier_features = random_feature_cls(kernel, n_components, dtype=tf.float64)
 
     x = tf.random.uniform((x_rows, n_dims), dtype=tf.float64)

--- a/tests/gpflux/sampling/test_sample.py
+++ b/tests/gpflux/sampling/test_sample.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 import gpflow
 from gpflow.config import default_float, default_jitter
 
-from gpflux.layers.basis_functions.fourier_features import RandomFourierFeatures
+from gpflux.layers.basis_functions.fourier_features import RandomFourierFeaturesCosine
 from gpflux.sampling.kernel_with_feature_decomposition import KernelWithFeatureDecomposition
 from gpflux.sampling.sample import Sample, efficient_sample
 
@@ -77,7 +77,7 @@ def test_conditional_sample(kernel, inducing_variable, whiten):
 
 def test_wilson_efficient_sample(kernel, inducing_variable, whiten):
     """Smoke and consistency test for efficient sampling using Wilson"""
-    eigenfunctions = RandomFourierFeatures(kernel, 100, dtype=default_float())
+    eigenfunctions = RandomFourierFeaturesCosine(kernel, 100, dtype=default_float())
     eigenvalues = np.ones((100, 1), dtype=default_float())
     # To apply Wilson sampling we require the features and eigenvalues of the kernel
     kernel2 = KernelWithFeatureDecomposition(kernel, eigenfunctions, eigenvalues)

--- a/tests/gpflux/sampling/test_sample.py
+++ b/tests/gpflux/sampling/test_sample.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 import gpflow
 from gpflow.config import default_float, default_jitter
 
-from gpflux.layers.basis_functions.random_fourier_features import RandomFourierFeatures
+from gpflux.layers.basis_functions.fourier_features import RandomFourierFeatures
 from gpflux.sampling.kernel_with_feature_decomposition import KernelWithFeatureDecomposition
 from gpflux.sampling.sample import Sample, efficient_sample
 


### PR DESCRIPTION
Significant refactoring and introduction of class hierarchies and abstract bases classes to better support the implementation of quadrature Fourier features (QFFs) and the different variants of random Fourier features (RFFs) with minimal code repetition.

### Noteworthy changes

1. Instead of directly specifying the `output_dim`, the user now supplies the number of samples drawn from the kernel's spectral density in the case of RFFs or the number of quadrature points to utilize in the case of QFFs. The effective output dimensions for all the supported types of basis functions are:
    - `RandomFourierFeaturesCosine`: `output_dim = n_components`
    - `RandomFourierFeatures`: `output_dim = 2 * n_components`
    - `QuadratureFourierFeatures`: `output_dim = 2 * n_components**input_dim`
2. The notebooks depending on random Fourier features have been updated to use `RandomFourierFeaturesCosine` for now to keep the necessary set of changes minimal (to use `RandomFourierFeatures` in these notebooks, we are required to update various parts of the notebook to reflect the fact that the `output_dim` is now different.)