### PR TITLE
adding import in init to make "fourier_features" module available

### DIFF
--- a/gpflux/layers/basis_functions/__init__.py
+++ b/gpflux/layers/basis_functions/__init__.py
@@ -16,3 +16,5 @@
 """
 Basis functions.
 """
+
+from . import fourier_features

--- a/gpflux/layers/basis_functions/__init__.py
+++ b/gpflux/layers/basis_functions/__init__.py
@@ -17,4 +17,3 @@
 Basis functions.
 """
 from gpflux.layers.basis_functions import fourier_features
-

--- a/gpflux/layers/basis_functions/__init__.py
+++ b/gpflux/layers/basis_functions/__init__.py
@@ -16,5 +16,5 @@
 """
 Basis functions.
 """
+from gpflux.layers.basis_functions import fourier_features
 
-from . import fourier_features

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,6 +1,7 @@
 # Code quality tools:
 black==20.8b1
 codecov
+click==8.0.2
 flake8==3.8.4
 isort==5.6.4
 mypy==0.770


### PR DESCRIPTION
This PR makes it possible to call `RandomFourierFeatures` as follows:
```
gpflux.layers.basis_functions.fourier_features.RandomFourierFeatures
```
instead of having to do
```
gpflux.layers.basis_functions.fourier_features import RandomFourierFeatures
```