### PR TITLE
removing dependency on setting the Keras backend

### DIFF
--- a/benchmarking/main.py
+++ b/benchmarking/main.py
@@ -29,8 +29,6 @@ from utils import ExperimentName, git_version
 
 from gpflux.architectures import Config, build_constant_input_dim_deep_gp
 
-tf.keras.backend.set_floatx("float64")
-
 THIS_DIR = Path(__file__).parent
 LOGS = THIS_DIR / "tmp"
 EXPERIMENT = Experiment("UCI")

--- a/docs/notebooks/deep_cde.ipynb
+++ b/docs/notebooks/deep_cde.ipynb
@@ -23,10 +23,7 @@
     "from tqdm import tqdm\n",
     "\n",
     "import tensorflow_probability as tfp\n",
-    "from sklearn.neighbors import KernelDensity\n",
-    "\n",
-    "\n",
-    "tf.keras.backend.set_floatx(\"float64\")"
+    "from sklearn.neighbors import KernelDensity\n"
    ],
    "outputs": [],
    "metadata": {}

--- a/docs/notebooks/efficient_sampling.py
+++ b/docs/notebooks/efficient_sampling.py
@@ -40,7 +40,6 @@ from gpflux.layers.basis_functions.fourier_features import RandomFourierFeatures
 from gpflux.sampling import KernelWithFeatureDecomposition
 from gpflux.models.deep_gp import sample_dgp
 
-tf.keras.backend.set_floatx("float64")
 
 # %% [markdown]
 """

--- a/docs/notebooks/gpflux_features.py
+++ b/docs/notebooks/gpflux_features.py
@@ -33,7 +33,6 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 
-tf.keras.backend.set_floatx("float64")  # we want to carry out GP calculations in 64 bit
 tf.get_logger().setLevel("INFO")
 
 

--- a/docs/notebooks/gpflux_with_keras_layers.py
+++ b/docs/notebooks/gpflux_with_keras_layers.py
@@ -30,7 +30,6 @@ import gpflux
 
 from gpflow.config import default_float
 
-tf.keras.backend.set_floatx("float64")
 
 # %% [markdown]
 """

--- a/docs/notebooks/intro.py
+++ b/docs/notebooks/intro.py
@@ -26,7 +26,6 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 
-tf.keras.backend.set_floatx("float64")
 tf.get_logger().setLevel("INFO")
 
 # %% [markdown]

--- a/docs/notebooks/keras_integration.py
+++ b/docs/notebooks/keras_integration.py
@@ -28,8 +28,6 @@ from gpflow.ci_utils import ci_niter
 
 import matplotlib.pyplot as plt
 
-# %%
-tf.keras.backend.set_floatx("float64")
 
 # %%
 # %matplotlib inline

--- a/gpflux/architectures/constant_input_dim_deep_gp.py
+++ b/gpflux/architectures/constant_input_dim_deep_gp.py
@@ -113,6 +113,12 @@ def build_constant_input_dim_deep_gp(X: np.ndarray, num_layers: int, config: Con
     :param num_layers: The number of layers in the Deep GP.
     :param config: The configuration for (hyper)parameters. See :class:`Config` for details.
     """
+    if X.dtype != gpflow.default_float():
+        raise ValueError(
+            f"X needs to have dtype according to gpflow.default_float() = {gpflow.default_float()} "
+            f"however got X with {X.dtype} dtype."
+        )
+
     num_data, input_dim = X.shape
     X_running = X
 

--- a/gpflux/layers/latent_variable_layer.py
+++ b/gpflux/layers/latent_variable_layer.py
@@ -95,8 +95,8 @@ class LatentVariableLayer(LayerWithObservations):
         :param compositor: A layer that combines layer inputs and latent variable
             samples into a single tensor; see :attr:`compositor`. If you do not specify a value for
             this parameter, the default is
-            ``tf.keras.layers.Concatenate(axis=-1,dtype=default_float())``. Note that you should
-            set ``dtype`` of the layer to GPflow default dtype as in
+            ``tf.keras.layers.Concatenate(axis=-1, dtype=default_float())``. Note that you should
+            set ``dtype`` of the layer to GPflow's default dtype as in
             :meth:`~gpflow.default_float()`.
         :param name: The name of this layer (passed through to `tf.keras.layers.Layer`).
         """

--- a/gpflux/layers/latent_variable_layer.py
+++ b/gpflux/layers/latent_variable_layer.py
@@ -94,7 +94,10 @@ class LatentVariableLayer(LayerWithObservations):
             posterior distribution; see :attr:`encoder`.
         :param compositor: A layer that combines layer inputs and latent variable
             samples into a single tensor; see :attr:`compositor`. If you do not specify a value for
-            this parameter, the default is ``tf.keras.layers.Concatenate(axis=-1)``.
+            this parameter, the default is 
+            ``tf.keras.layers.Concatenate(axis=-1,dtype=default_float())``. Note that you should
+            set ``dtype`` of the layer to GPflow default dtype as in
+            :meth:`~gpflow.default_float()`.
         :param name: The name of this layer (passed through to `tf.keras.layers.Layer`).
         """
 
@@ -103,7 +106,7 @@ class LatentVariableLayer(LayerWithObservations):
         self.distribution_class = prior.__class__
         self.encoder = encoder
         self.compositor = (
-            compositor if compositor is not None else tf.keras.layers.Concatenate(axis=-1)
+            compositor if compositor is not None else tf.keras.layers.Concatenate(axis=-1, dtype=default_float())
         )
 
     def call(

--- a/gpflux/layers/latent_variable_layer.py
+++ b/gpflux/layers/latent_variable_layer.py
@@ -94,7 +94,7 @@ class LatentVariableLayer(LayerWithObservations):
             posterior distribution; see :attr:`encoder`.
         :param compositor: A layer that combines layer inputs and latent variable
             samples into a single tensor; see :attr:`compositor`. If you do not specify a value for
-            this parameter, the default is 
+            this parameter, the default is
             ``tf.keras.layers.Concatenate(axis=-1,dtype=default_float())``. Note that you should
             set ``dtype`` of the layer to GPflow default dtype as in
             :meth:`~gpflow.default_float()`.
@@ -106,7 +106,9 @@ class LatentVariableLayer(LayerWithObservations):
         self.distribution_class = prior.__class__
         self.encoder = encoder
         self.compositor = (
-            compositor if compositor is not None else tf.keras.layers.Concatenate(axis=-1, dtype=default_float())
+            compositor
+            if compositor is not None
+            else tf.keras.layers.Concatenate(axis=-1, dtype=default_float())
         )
 
     def call(

--- a/gpflux/models/deep_gp.py
+++ b/gpflux/models/deep_gp.py
@@ -96,8 +96,8 @@ class DeepGP(Module):
             If you do not specify a value for this parameter explicitly, it is automatically
             detected from the :attr:`~gpflux.layers.GPLayer.num_data` attribute in the GP layers.
         """
-        self.inputs = tf.keras.Input((input_dim,), name="inputs")
-        self.targets = tf.keras.Input((target_dim,), name="targets")
+        self.inputs = tf.keras.Input((input_dim,), dtype=tf.float64, name="inputs")
+        self.targets = tf.keras.Input((target_dim,), dtype=tf.float64, name="targets")
         self.f_layers = f_layers
         if isinstance(likelihood, gpflow.likelihoods.Likelihood):
             self.likelihood_layer = LikelihoodLayer(likelihood)

--- a/gpflux/models/deep_gp.py
+++ b/gpflux/models/deep_gp.py
@@ -37,6 +37,9 @@ class DeepGP(Module):
     inheriting from :class:`~gpflux.layers.LayerWithObservations`; those will
     be passed the argument ``observations=[inputs, targets]``.
 
+    When data is used with methods in this class (e.g. :meth:`predict_f` method), it needs to
+    be with ``dtype`` corresponding to GPflow's default dtype as in :meth:`~gpflow.default_float()`.
+
     .. note:: This class is **not** a `tf.keras.Model` subclass itself. To access
        Keras features, call either :meth:`as_training_model` or :meth:`as_prediction_model`
        (depending on the use-case) to create a `tf.keras.Model` instance. See the method docstrings
@@ -96,8 +99,8 @@ class DeepGP(Module):
             If you do not specify a value for this parameter explicitly, it is automatically
             detected from the :attr:`~gpflux.layers.GPLayer.num_data` attribute in the GP layers.
         """
-        self.inputs = tf.keras.Input((input_dim,), dtype=tf.float64, name="inputs")
-        self.targets = tf.keras.Input((target_dim,), dtype=tf.float64, name="targets")
+        self.inputs = tf.keras.Input((input_dim,), dtype=gpflow.default_float(), name="inputs")
+        self.targets = tf.keras.Input((target_dim,), dtype=gpflow.default_float(), name="targets")
         self.f_layers = f_layers
         if isinstance(likelihood, gpflow.likelihoods.Likelihood):
             self.likelihood_layer = LikelihoodLayer(likelihood)
@@ -129,6 +132,20 @@ class DeepGP(Module):
         if num_data is None:
             raise ValueError("Could not determine num_data; please provide explicitly")
         return num_data
+
+    @staticmethod
+    def _validate_dtype(x: TensorType) -> None:
+        """
+        Check that data ``x`` is of correct ``dtype``, corresponding to GPflow's default dtype as
+        defined by :meth:`~gpflow.default_float()`.
+
+        :raise ValueError: If ``x`` is of incorrect ``dtype.
+        """
+        if x.dtype != gpflow.default_float():
+            raise ValueError(
+                f"x needs to have dtype {gpflow.default_float()} (according to "
+                f"gpflow.default_float()), however got x with {x.dtype} dtype."
+            )
 
     def _evaluate_deep_gp(
         self,
@@ -180,6 +197,9 @@ class DeepGP(Module):
         targets: Optional[TensorType] = None,
         training: Optional[bool] = None,
     ) -> tf.Tensor:
+        self._validate_dtype(inputs)
+        if targets is not None:
+            self._validate_dtype(targets)
         f_outputs = self._evaluate_deep_gp(inputs, targets=targets, training=training)
         y_outputs = self._evaluate_likelihood(f_outputs, targets=targets, training=training)
         return y_outputs
@@ -188,9 +208,11 @@ class DeepGP(Module):
         """
         :returns: The mean and variance (not the scale!) of ``f``, for compatibility with GPflow
            models.
+        :raise ValueError: If ``x`` is of incorrect ``dtype.
 
         .. note:: This method does **not** support ``full_cov`` or ``full_output_cov``.
         """
+        self._validate_dtype(inputs)
         f_distribution = self._evaluate_deep_gp(inputs, targets=None)
         return f_distribution.loc, f_distribution.scale.diag ** 2
 

--- a/gpflux/models/deep_gp.py
+++ b/gpflux/models/deep_gp.py
@@ -139,7 +139,7 @@ class DeepGP(Module):
         Check that data ``x`` is of correct ``dtype``, corresponding to GPflow's default dtype as
         defined by :meth:`~gpflow.default_float()`.
 
-        :raise ValueError: If ``x`` is of incorrect ``dtype.
+        :raise ValueError: If ``x`` is of incorrect ``dtype``.
         """
         if x.dtype != gpflow.default_float():
             raise ValueError(
@@ -208,7 +208,7 @@ class DeepGP(Module):
         """
         :returns: The mean and variance (not the scale!) of ``f``, for compatibility with GPflow
            models.
-        :raise ValueError: If ``x`` is of incorrect ``dtype.
+        :raise ValueError: If ``x`` is of incorrect ``dtype``.
 
         .. note:: This method does **not** support ``full_cov`` or ``full_output_cov``.
         """

--- a/tests/gpflux/architectures/test_constant_input_dim_deep_gp.py
+++ b/tests/gpflux/architectures/test_constant_input_dim_deep_gp.py
@@ -26,3 +26,12 @@ def test_smoke_build_constant_input_dim_deep_gp(input_dim, num_layers):
     model_train.fit((X, Y), epochs=1)
     model_test = dgp.as_prediction_model()
     _ = model_test(X)
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.int32])
+def test_build_constant_input_dim_deep_gp_raises_on_incorrect_dtype(dtype):
+    config = make_dataclass_from_class(Config, DemoConfig)
+    X = np.random.randn(13, 2).astype(dtype)
+
+    with pytest.raises(ValueError):
+        build_constant_input_dim_deep_gp(X, 2, config)

--- a/tests/gpflux/architectures/test_constant_input_dim_deep_gp.py
+++ b/tests/gpflux/architectures/test_constant_input_dim_deep_gp.py
@@ -5,8 +5,6 @@ import tensorflow as tf
 from gpflux.architectures import Config, build_constant_input_dim_deep_gp
 from gpflux.helpers import make_dataclass_from_class
 
-tf.keras.backend.set_floatx("float64")
-
 
 class DemoConfig:
     num_inducing = 7

--- a/tests/gpflux/layers/test_latent_variable_layer.py
+++ b/tests/gpflux/layers/test_latent_variable_layer.py
@@ -26,7 +26,6 @@ from gpflow.kullback_leiblers import gauss_kl
 from gpflux.encoders import DirectlyParameterizedNormalDiag
 from gpflux.layers import LatentVariableLayer, LayerWithObservations, TrackableLayer
 
-tf.keras.backend.set_floatx("float64")
 
 ############
 # Utilities

--- a/tests/gpflux/layers/test_latent_variable_layer.py
+++ b/tests/gpflux/layers/test_latent_variable_layer.py
@@ -26,7 +26,6 @@ from gpflow.kullback_leiblers import gauss_kl
 from gpflux.encoders import DirectlyParameterizedNormalDiag
 from gpflux.layers import LatentVariableLayer, LayerWithObservations, TrackableLayer
 
-
 ############
 # Utilities
 ############

--- a/tests/gpflux/models/test_bayesian_model.py
+++ b/tests/gpflux/models/test_bayesian_model.py
@@ -24,8 +24,6 @@ from gpflow.likelihoods import Gaussian
 from gpflux.layers import LatentVariableLayer, LikelihoodLayer
 from tests.integration.test_latent_variable_integration import build_gp_layers  # noqa: F401
 
-tf.keras.backend.set_floatx("float64")
-
 MAXITER = int(80e3)
 PLOTTER_INTERVAL = 60
 

--- a/tests/gpflux/models/test_deep_gp.py
+++ b/tests/gpflux/models/test_deep_gp.py
@@ -133,7 +133,6 @@ def get_live_plotter(train_data, model):
 
 
 def run_demo(maxiter=int(80e3), plotter_interval=60):
-    tf.keras.backend.set_floatx("float64")
     input_dim = 2
     num_data = 1000
     data = setup_dataset(input_dim, num_data)

--- a/tests/gpflux/models/test_deep_gp.py
+++ b/tests/gpflux/models/test_deep_gp.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import numpy as np
+import pytest
 import tensorflow as tf
 import tqdm
 
@@ -81,7 +82,7 @@ def train_deep_gp(deep_gp, data, maxiter=MAXITER, plotter=None, plotter_interval
                 plotter()
 
 
-def setup_dataset(input_dim: int, num_data: int):
+def setup_dataset(input_dim: int, num_data: int, dtype: np.dtype = np.float64):
     lim = [0, 100]
     kernel = RBF(lengthscales=20)
     sigma = 0.01
@@ -89,7 +90,7 @@ def setup_dataset(input_dim: int, num_data: int):
     cov = kernel.K(X) + np.eye(num_data) * sigma ** 2
     Y = np.random.multivariate_normal(np.zeros(num_data), cov)[:, None]
     Y = np.clip(Y, -0.5, 0.5)
-    return X, Y
+    return X.astype(dtype), Y.astype(dtype)
 
 
 def get_live_plotter(train_data, model):
@@ -152,6 +153,23 @@ def test_smoke():
 
     matplotlib.use("PS")  # Agg does not support 3D
     run_demo(maxiter=2, plotter_interval=1)
+
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.int32])
+def test_deep_gp_raises_on_incorrect_dtype(dtype):
+    input_dim = 2
+    num_data = 1000
+    X, Y = setup_dataset(input_dim, num_data, dtype)
+    model = build_deep_gp(input_dim, num_data)
+
+    with pytest.raises(ValueError):
+        model.predict_f(X)
+
+    with pytest.raises(ValueError):
+        model.call(X)
+
+    with pytest.raises(ValueError):
+        model.call(X, Y)
 
 
 if __name__ == "__main__":

--- a/tests/gpflux/test_losses.py
+++ b/tests/gpflux/test_losses.py
@@ -7,8 +7,6 @@ import gpflow
 from gpflux.layers import LikelihoodLayer
 from gpflux.losses import LikelihoodLoss
 
-tf.keras.backend.set_floatx("float64")
-
 
 def test_likelihood_layer_and_likelihood_loss_give_equal_results():
     np.random.seed(123)

--- a/tests/integration/test_compilation.py
+++ b/tests/integration/test_compilation.py
@@ -27,9 +27,6 @@ from gpflux.layers import GPLayer, LikelihoodLayer, TrackableLayer
 from gpflux.losses import LikelihoodLoss
 from gpflux.models import DeepGP
 
-tf.keras.backend.set_floatx("float64")
-
-
 #########################################
 # Helpers
 #########################################

--- a/tests/integration/test_latent_variable_integration.py
+++ b/tests/integration/test_latent_variable_integration.py
@@ -30,8 +30,6 @@ from gpflux.helpers import construct_basic_inducing_variables, construct_basic_k
 from gpflux.layers import GPLayer, LatentVariableLayer, LikelihoodLayer
 from gpflux.models import DeepGP
 
-tf.keras.backend.set_floatx("float64")
-
 ############
 # Utilities
 ############


### PR DESCRIPTION
this PR addresses #76, fix was fairly straightforward, the rest was removing backend calls throughout the repo

there was a tiny bit discrepancy in some tests in `GPflux/tests/integration/test_svgp_equivalence.py`, couldn't pinpoint where it was coming from

while this avoids setting the backend, one still needs to be careful that float64 data is given to the model (which is the case in all the tests at the moment), @vdutor how do you want to go about this? just warn the user in docstrings and some notebooks, or implement data check in `DeepGP` class (perhaps somewhere else as well?)?