### PR TITLE
Update to newer GPflow and TensorFlow.

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
           python-version: ["3.7", "3.8", "3.9", "3.10"]
-          tensorflow: ["~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0"]
+          tensorflow: ["~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", "~=2.9.0", "~=2.10.0"]
           include:
             - tensorflow: "~=2.5.0"
               keras: "~=2.6.0"
@@ -36,6 +36,12 @@ jobs:
             - tensorflow: "~=2.8.0"
               keras: "~=2.8.0"
               tensorflow-probability: "~=0.16.0"
+            - tensorflow: "~=2.9.0"
+              keras: "~=2.9.0"
+              tensorflow-probability: "~=0.17.0"
+            - tensorflow: "~=2.10.0"
+              keras: "~=2.10.0"
+              tensorflow-probability: "~=0.18.0"
           exclude:
             # These older versions of TensorFlow don't work with Python 3.10:
             - python-version: "3.10"

--- a/docs/notebooks/keras_integration.py
+++ b/docs/notebooks/keras_integration.py
@@ -24,7 +24,7 @@ import numpy as np
 import tensorflow as tf
 import gpflow
 import gpflux
-from gpflow.ci_utils import ci_niter
+from gpflow.ci_utils import reduce_in_tests
 
 import matplotlib.pyplot as plt
 
@@ -80,7 +80,7 @@ def create_model(model_class):
 
 # %%
 batch_size = 2
-num_epochs = ci_niter(200)
+num_epochs = reduce_in_tests(200)
 
 # %%
 dgp = create_model(tf.keras.Model)

--- a/gpflux/layers/likelihood_layer.py
+++ b/gpflux/layers/likelihood_layer.py
@@ -77,6 +77,7 @@ class LikelihoodLayer(TrackableLayer):
         """
         # TODO: add support for non-distribution inputs? or other distributions?
         assert isinstance(unwrap_dist(inputs), tfp.distributions.MultivariateNormalDiag)
+        no_X = None
         F_mean = inputs.loc
         F_var = inputs.scale.diag ** 2
 
@@ -84,12 +85,12 @@ class LikelihoodLayer(TrackableLayer):
             assert targets is not None
             # TODO: re-use LikelihoodLoss to remove code duplication
             loss_per_datapoint = tf.reduce_mean(
-                -self.likelihood.variational_expectations(F_mean, F_var, targets)
+                -self.likelihood.variational_expectations(no_X, F_mean, F_var, targets)
             )
             Y_mean = Y_var = None
         else:
             loss_per_datapoint = tf.constant(0.0, dtype=default_float())
-            Y_mean, Y_var = self.likelihood.predict_mean_and_var(F_mean, F_var)
+            Y_mean, Y_var = self.likelihood.predict_mean_and_var(no_X, F_mean, F_var)
 
         self.add_loss(loss_per_datapoint)
 

--- a/gpflux/losses.py
+++ b/gpflux/losses.py
@@ -79,11 +79,12 @@ class LikelihoodLoss(tf.keras.losses.Loss):
         Note that we deviate from the Keras Loss interface by calling the
         second argument *f_prediction* rather than *y_pred*.
         """
+        no_X = None
         if isinstance(unwrap_dist(f_prediction), tfp.distributions.MultivariateNormalDiag):
 
             F_mu = f_prediction.loc
             F_var = f_prediction.scale.diag ** 2
-            return -self.likelihood.variational_expectations(F_mu, F_var, y_true)
+            return -self.likelihood.variational_expectations(no_X, F_mu, F_var, y_true)
         else:  # Tensor
             f_samples = f_prediction
-            return -self.likelihood.log_prob(f_samples, y_true)
+            return -self.likelihood.log_prob(no_X, f_samples, y_true)

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ from setuptools import find_namespace_packages, setup
 
 requirements = [
     "deprecated",
-    "gpflow>=2.1",
+    "gpflow>=2.6.3",
     "numpy",
     "scipy",
-    "tensorflow>=2.5.0,<2.9.0; platform_system!='Darwin' or platform_machine!='arm64'",
+    "tensorflow>=2.5.0,<2.11.0; platform_system!='Darwin' or platform_machine!='arm64'",
     # NOTE: Support of Apple Silicon MacOS platforms is in an experimental mode
-    "tensorflow-macos>=2.5.0,<2.9.0; platform_system=='Darwin' and platform_machine=='arm64'",
+    "tensorflow-macos>=2.5.0,<2.11.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
-    "tensorflow-probability>=0.13.0,<0.17.0",
+    "tensorflow-probability>=0.13.0,<0.19.0",
     "protobuf~=3.19.0"
 ]
 

--- a/tests/gpflux/layers/test_likelihood_layer.py
+++ b/tests/gpflux/layers/test_likelihood_layer.py
@@ -93,7 +93,7 @@ def test_likelihood_layer_losses(GPflowLikelihood):
 
     f_mean = f_distribution.loc
     f_var = f_distribution.scale.diag ** 2
-    expected_loss = np.mean(-likelihood.variational_expectations(f_mean, f_var, Y))
+    expected_loss = np.mean(-likelihood.variational_expectations(X, f_mean, f_var, Y))
 
     np.testing.assert_almost_equal(keras_loss, expected_loss, decimal=5)
 
@@ -109,13 +109,13 @@ def test_likelihood_loss(GPflowLikelihood):
     f_mean = f_distribution.loc
     f_var = f_distribution.scale.diag
 
-    expected_loss = np.mean(-likelihood.variational_expectations(f_mean, f_var, Y))
+    expected_loss = np.mean(-likelihood.variational_expectations(X, f_mean, f_var, Y))
     np.testing.assert_almost_equal(likelihood_loss(Y, f_distribution), expected_loss, decimal=5)
 
     # 2. Run tests with gp_layer output coerced to sample
     f_sample = tf.convert_to_tensor(gp_layer(X))
 
-    expected_loss = np.mean(-likelihood.log_prob(f_sample, Y))
+    expected_loss = np.mean(-likelihood.log_prob(X, f_sample, Y))
     np.testing.assert_almost_equal(likelihood_loss(Y, f_sample), expected_loss, decimal=5)
 
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -12,6 +12,7 @@ pytest-mock
 
 # For mypy stubs:
 types-Deprecated
+numpy<1.22.0  # Newer versions of numpy are not compatible with Python 3.7.
 
 tqdm
 


### PR DESCRIPTION
Update to make GPflux compatible with newer versions of GPflow, that require an additional `X` parameter in the likelihoods.
In this PR I just pass a dummy `None` value as `X`. Alternatively we could:

1. I don't know Keras and GPflux well, but maybe we can find a "real" value of `X` to use?
2. Do we want to attempt to write code that's compatible with earlier version of GPflow as well? I suppose we could add an `if` somewhere?