### PR TITLE
Ignore error that conflicts with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,8 @@
 # W503 Line break occurred before a binary operator
 # W504 line break after binary operator
 # F811 redefinition because of multiple dispatch
-ignore = E226,W503,W504,F811
+# E203 whitespace before ':'
+ignore = E226,W503,W504,F811,E203
 max-line-length = 100
 max-complexity = 10
 exclude = .git,__pycache__,.mypy_cache,.pytest_cache


### PR DESCRIPTION
Flake8's E203, whitespace before colon, conflicts with black's demand that there is space before a colon.  I couldn't care less either way, but black at least fixes the problem itself, so let's disable E203.