### PR TITLE
Made test a bit less strict

### DIFF
--- a/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
+++ b/tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py
@@ -132,7 +132,7 @@ def test_feature_map_decomposition(kernel_cls, variance, lengthscale, n_dims, n_
     )
     K_quadrature = tf.squeeze(K_quadrature, axis=-1)
 
-    np.testing.assert_allclose(K_decomp, K_quadrature, atol=1e-15)
+    np.testing.assert_allclose(K_decomp, K_quadrature, atol=1e-12)
 
 
 def test_fourier_features_shapes(n_components, n_dims, batch_size):


### PR DESCRIPTION
The test tests/gpflux/layers/basis_functions/fourier_features/test_quadrature.py::test_feature_map_decomposition is failing on code that seemingly hasn't touched anything to do with it.  Hrvoje and Sebastian agree that the test is probably too strict and the failure is stochastic.  This PR loosens the tolerance so it will pass.