### PR TITLE
Carry on using Ubuntu 20.04 for now

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -18,7 +18,7 @@ on: [push]
 
 jobs:
   check-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
           python-version: ["3.7", "3.8", "3.9", "3.10"]

--- a/.github/workflows/upload-pypi.yaml
+++ b/.github/workflows/upload-pypi.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   upload-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
ubuntu-latest has recently been updated to use Ubuntu 22.04, which seems to break our tests. While we investigate this we should continue to use the old builder.