### PR TITLE
Support tf < 2.14 and tfp < 0.22.0

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
           python-version: ["3.7", "3.8", "3.9", "3.10"]
-          tensorflow: ["~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", "~=2.9.0", "~=2.10.0", "~=2.11.0", "~=2.12.0"]
+          tensorflow: ["~=2.5.0", "~=2.6.0", "~=2.7.0", "~=2.8.0", "~=2.9.0", "~=2.10.0", "~=2.11.0", "~=2.12.0", "~=2.13.0"]
           include:
             - tensorflow: "~=2.5.0"
               keras: "~=2.6.0"
@@ -47,7 +47,13 @@ jobs:
               tensorflow-probability: "~=0.19.0"
             - tensorflow: "~=2.12.0"
               keras: "~=2.12.0"
-              tensorflow-probability: "~=0.19.0" # sic! no new tfp release
+              tensorflow-probability: "~=0.19.0"
+            - tensorflow: "~=2.13.0"
+              keras: "~=2.13.0"
+              tensorflow-probability: "~=0.20.0"
+            - tensorflow: "~=2.13.0"
+              keras: "~=2.13.0"
+              tensorflow-probability: "~=0.21.0"
           exclude:
             # These older versions of TensorFlow don't work with Python 3.10:
             - python-version: "3.10"

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ requirements = [
     "gpflow>=2.6.3",
     "numpy",
     "scipy",
-    "tensorflow>=2.5.0,<2.13.0; platform_system!='Darwin' or platform_machine!='arm64'",
+    "tensorflow>=2.5.0,<2.14.0; platform_system!='Darwin' or platform_machine!='arm64'",
     # NOTE: Support of Apple Silicon MacOS platforms is in an experimental mode
-    "tensorflow-macos>=2.5.0,<2.13.0; platform_system=='Darwin' and platform_machine=='arm64'",
+    "tensorflow-macos>=2.5.0,<2.14.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
-    "tensorflow-probability>=0.13.0,<0.20.0",
+    "tensorflow-probability>=0.13.0,<0.22.0",
 ]
 
 with open("README.md", "r") as file:


### PR DESCRIPTION
Updates dependencies to allow the latest versions of tensorflow ([2.13](https://pypi.org/project/tensorflow/)) and tensorflow-probability ([0.21](https://pypi.org/project/tensorflow-probability/)).