### PR TITLE
Active dimension support (including for combination kernels)

### DIFF
--- a/gpflux/layers/basis_functions/fourier_features/quadrature/gaussian.py
+++ b/gpflux/layers/basis_functions/fourier_features/quadrature/gaussian.py
@@ -19,7 +19,7 @@ quadrature aka Gaussian quadrature.
 """
 
 import warnings
-from typing import Mapping, Tuple, Type
+from typing import Mapping, Optional, Tuple, Type
 
 import tensorflow as tf
 
@@ -75,7 +75,7 @@ class QuadratureFourierFeatures(FourierFeaturesBase):
         input_dim = input_shape[-1]
         return 2 * self.n_components ** input_dim
 
-    def _compute_bases(self, inputs: TensorType) -> tf.Tensor:
+    def _compute_bases(self, inputs: TensorType, batch: Optional[int]) -> tf.Tensor:
         """
         Compute basis functions.
 

--- a/gpflux/layers/basis_functions/fourier_features/random/base.py
+++ b/gpflux/layers/basis_functions/fourier_features/random/base.py
@@ -123,8 +123,9 @@ class RandomFourierFeaturesBase(FourierFeaturesBase):
         return kernel.slice(dummy_X, None)[0].shape[-1]
 
     def _weights_build(self, input_dim: int, n_components: int) -> None:
+        # for batched layers we store a list of weights, as each may have a different
+        # active input dimension
         if self.is_batched:
-            # TODO: handle nested active_dims
             self.W = [
                 self.add_weight(
                     name="weights",
@@ -133,7 +134,7 @@ class RandomFourierFeaturesBase(FourierFeaturesBase):
                     dtype=self.dtype,
                     initializer=self._weights_init(k),
                 )
-                # SharedIndependent repeatedly use the same sub_kernel
+                # SharedIndependent repeatedly uses the same sub_kernel
                 for _, k in zip(range(self.batch_size), cycle(self.sub_kernels))
             ]
         else:
@@ -278,6 +279,7 @@ class RandomFourierFeaturesCosine(RandomFourierFeaturesBase):
         super(RandomFourierFeaturesCosine, self).build(input_shape)
 
     def _bias_build(self, n_components: int) -> None:
+        # for batched layers we store a list of biases, to match the weights structure
         if self.is_batched:
             self.b = [
                 self.add_weight(

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -9,12 +9,11 @@ pytest
 pytest-cov
 pytest-random-order
 pytest-mock
+tqdm
 
 # For mypy stubs:
 types-Deprecated
 numpy
-
-tqdm
 
 # Notebook tests:
 jupytext


### PR DESCRIPTION
Add support for active dims. In order to support combination kernels such as Sum or SeparateIndependent, weights need to be stored as a list of tensors rather than a single higher rank tensor, since the active input dimensions may vary between subkernels.